### PR TITLE
add: #9 ヘッターの表示分け、require_loginの設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::Base
+  before_action :require_login
+
+  private
+  def not_authenticated
+    redirect_to login_path
+  end
 end

--- a/app/controllers/staticpages_controller.rb
+++ b/app/controllers/staticpages_controller.rb
@@ -1,4 +1,5 @@
 class StaticpagesController < ApplicationController
+  skip_before_action :require_login, only: %i[top]
   def top
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,5 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
   def new;end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
   def new
       @user = User.new
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,11 @@
   </head>
 
   <body>
-    <%= render 'shared/before_login_header' %>
+    <% if logged_in? %>
+      <%= render 'shared/header' %>
+    <% else %>
+      <%= render 'shared/before_login_header'%>
+    <% end %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>


### PR DESCRIPTION
## issue番号
close: https://github.com/nakayama-bird/metime-meals/issues/9
## やったこと
- ログイン前後でヘッターの表示分け
- `require_login`を設定し、ログインしていない場合ログイン画面にリダイレクトされるようにした
- ログインが不要な動作については、`skip_before_action`を指定

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- ログイン前後で異なるヘッターが表示されるようになった
- ログイン必須のページにアクセスするとログイン画面が表示されるようになった

## できなくなること（ユーザ目線）


## 動作確認
- ローカルでの動作確認実施済み

## その他
- ログイン不要で使用できる機能が多いので必要の応じて`skip_before_action`を設定するのを忘れずに