### PR TITLE
add: #10 ログアウト機能の実装

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -11,5 +11,8 @@ class UserSessionsController < ApplicationController
     end
   end
 
-  def destroy;end
+  def destroy
+    logout
+    redirect_to root_path, status: :see_other
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">
         <li>
-          <%= link_to "マイページ", "#" %>
+          <%= link_to "ログアウト", logout_path, data: {turbo_method: :delete, turbo_confirm: 'ログアウトしてもよろしいですか？'} %>
         </li>
         <li>
           <details>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -8,7 +8,7 @@
       <%= "食事を楽しめる飲食店を探したい！という願いを叶えます"%>
       </p>
       <button class="btn btn-primary">
-        <%= link_to 'はじめてみる', "#"  %>
+        <%= link_to 'はじめてみる', login_path  %>
       </button>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   root 'staticpages#top'
   get 'login', to:'user_sessions#new'
   post 'login', to:'user_sessions#create'
+  delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/10
## やったこと
- ログイン時、ヘッターからログアウトできるように実装

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- ログインしたユーザーがログアウトできるようにした

## できなくなること（ユーザ目線）


## 動作確認
- デプロイして既存のユーザーでログイン、ログアウト機能、ヘッターの表示分けの動作確認済み

## その他