### PR TITLE
add: #11 フラッシュメッセージの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
 
+  add_flash_types :success, :danger
+
   private
   def not_authenticated
     redirect_to login_path

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,14 +5,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_to root_path
+      redirect_to root_path, success: 'ログインに成功しました'
     else
-      render :new
+      flash.now[:alert] = 'ログインに失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to root_path, status: :see_other
+    redirect_to root_path, status: :see_other, success: 'ログアウトに成功しました'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,9 +7,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path
+      redirect_to root_path, success: 'ユーザー登録に成功しました'
     else
-      render :new
+      flash.now[:alert] = 'ユーザー登録に失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym #シンボルに変換
+      when :success then 'bg-success'
+      when :alert then 'bg-error'
+      else 'bg-grey-500'
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <% else %>
       <%= render 'shared/before_login_header'%>
     <% end %>
+    <%= render 'shared/flash_messages' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type,message|%>
+    <div class='<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-4'>
+        <%= message %>
+    </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module Myapp
     # タイムゾーンの設定
     config.time_zone = "Tokyo"
 
+    # デフォルト言語の設定
     config.i18n.default_locale = :ja
 
     # config.eager_load_paths << Rails.root.join("extras")

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module Myapp
     config.time_zone = "Tokyo"
 
     # デフォルト言語の設定
-    config.i18n.default_locale = :ja
+    # config.i18n.default_locale = :ja
 
     # config.eager_load_paths << Rails.root.join("extras")
   end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/11
## やったこと
- 成功時、失敗時のフラッシュメッセージ作成
- 投稿失敗時にエラーになってしまっていたので、destroyアクションで`status: :unprocessable_entity`を追加
- i18nの設定が原因でエラーになったので一旦削除

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- ログイン成功・失敗時にフラッシュメッセージを表示
- ユーザー登録成功・失敗時にフラッシュメッセージを表示

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境での動作確認済み

## その他
- 本番環境でのUser登録失敗の際のエラーのログ（一部省略）
```
ActionView::Template::Error (:ja is not a valid locale):
#...  4:     </div>
#...  5:     <%= form_with model: @user do |f| %>
```