### PR TITLE
add: #32 Googleアナリティクスの設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,15 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-K5HPRJCQX8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-K5HPRJCQX8');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/32

## やったこと
- Googleアナリティクスの設定
- `app/views/layouts/application.html.erb`での設定

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
-デプロイしてアナリティクスの計測の動作確認済み

## その他
- 自分の端末からの計測の設定については下記の通り
   - PCのクローム：拡張機能で無効化（切れば反映される）
   - スマホのSafari：広告ブロック導入済みのため計測されず
   - スマホのChrome：計測されること確認済み