### PR TITLE
add: #50 料理ジャンルを設定できるよう実装

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,6 +4,9 @@ class Post < ApplicationRecord
   validates :body, presence: true, length: {maximum: 65_535 }
   validates :latitude, presence: true
   validates :longitude, presence: true
+  validates :genre, presence: true
+  enum genre: { japanese_food: 0, chinese_food: 1, western_food: 2, korean_food: 3, ethnic_food: 4,
+ramen: 10, curry: 11, cafe: 20, bar: 21, other: 99}
 
   # geocodingについての設定
   geocoded_by :address

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,7 +5,7 @@
     <div class="w-full md:w-2/3 bg-white flex flex-col space-y-2 p-3">
         <div class="flex justify-between item-center">
             <div class="flex items-center">
-                <p class="text-gray-600 font-bold text-sm ml-1">ジャンル</p>
+                <p class="text-gray-600 font-bold text-sm ml-1"><%= post.genre %></p>
             </div>
         </div>
         <h3 class="font-black text-gray-800 md:text-3xl text-xl"><%= post.restaurant_name %></h3>

--- a/db/migrate/20240718074423_add_genre_to_posts.rb
+++ b/db/migrate/20240718074423_add_genre_to_posts.rb
@@ -1,0 +1,5 @@
+class AddGenreToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :genre, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_015943) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_074423) do
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "restaurant_name", null: false
     t.string "address", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_015943) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "genre", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,6 +26,7 @@ user_ids = User.ids
     address: "住所#{index}",
     latitude: 50,
     longitude: 50,
-    body: "本文#{index}"
+    body: "本文#{index}",
+    genre: [0,1,2,3,4,10,11,20,21,99].sample
     )
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/50
## やったこと
- Postテーブルにgenreカラムを追加
- enumで料理のジャンルを表示できるようにした
- ジャンルを一覧画面で表示

## できなかったこと・やらなかったこと
- enumを日本語で表示するためには国際化の設定が必要だったため別issueで対応

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 開発環境では、seedファイルを使用して一覧画面に表示ができる旨確認済み
- 本番環境では投稿なしの状態でエラーがないこと確認済み

## その他