### PR TITLE
add: #20 投稿編集機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,6 +22,20 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  def edit
+    @post = current_user.posts.find(params[:id])
+  end
+
+  def update
+    @post = current_user.posts.find(params[:id])
+    if @post.update(post_params)
+      redirect_to post_path(post_params), success: '投稿の更新に成功しました'
+    else
+      flash.now[:alert] = '投稿の更新に失敗しました'
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
     def post_params
       params.require(:post).permit(:genre, :restaurant_name, :address, :body, :amount)

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with model: post do |f| %>
+    <%= f.label :genre, '料理のジャンル', class: 'label w-full md:w-1/2 mx-auto' %>
+    <div class='mx-auto w-full md:w-1/2 text-center'>
+        <%= f.select :genre, Post.enum_options_for_select(:genre), { include_blank: "未選択" },
+                    class: 'bg-card-body bg-base-100 rounded-3xl border border-accent py-2 px-3 mb-6 w-full md:w-1/2 mx-auto' %>
+    </div>
+
+    <%= f.label :restaurant_name, 'お店の名前', class: 'label w-full md:w-1/2 mx-auto' %>
+    <%= f.text_field :restaurant_name, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto', placeholder: 'お店の名前を入力してください' %>
+
+    <%= f.label :address, '住所', class: 'label w-full md:w-1/2 mx-auto' %>
+    <%= f.text_field :address, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto' %>
+
+
+
+    <%= f.label :body, 'おすすめポイント', class: 'label w-full md:w-1/2 mx-auto' %>
+    <%= f.text_area :body, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto h-auto', rows: 5, placeholder: 'おすすめメニューや感想などを入力しましょう' %>
+
+    <%= f.label :amount, '使った金額(任意)', class: 'label w-full md:w-1/2 mx-auto' %>
+    <div class='mx-auto w-full md:w-1/2 text-center'>
+        <%= f.select :amount, Post.enum_options_for_select(:amount), { include_blank: "未選択" },
+                    class: 'bg-card-body bg-base-100 rounded-3xl border border-accent py-2 px-3 mb-6 w-full md:w-1/2 mx-auto' %>
+    </div>
+
+    <div class='mx-auto md:w-1/2'>
+        <%= f.submit '投稿', class: 'btn btn-primary w-full my-6' %>
+    </div>
+<% end %>
+<div class='text-center mb-6'>
+    <%= link_to'投稿一覧ページへ', posts_path %>
+</div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,6 +1,6 @@
 <div class='container'>
     <div class='text-center mt-6'>
-        <h1 class='text-2xl font-semibold'>新規投稿</h1>
+        <h1 class='text-2xl font-semibold'>投稿編集</h1>
     </div>
     <%= render 'form', post: @post %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -38,7 +38,7 @@
         <div class='col-start-2 col-end-3 flex items-center'><%= @post.user.name %></div>
             <% if logged_in? %>
                 <% if current_user.own?(@post)%>
-                    <div class='col-start-6'><%= link_to '編集', '#', class: "btn btn-primary" %></div>
+                    <div class='col-start-6'><%= link_to '編集', edit_post_path(@post), class: "btn btn-primary" %></div>
                     <div class='col-start-7'><%= link_to '削除', '#', class: "btn btn-secondary" %></div>
                 <% end %>
             <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,7 +18,7 @@
               <ul class="p-2 bg-base-200 rounded-t-none z-50">
                 <li><%= link_to "一覧で探す", posts_path %></li>
                 <li><%= link_to "マップで探す", "#" %></li>
-                <li><%= link_to "新規投稿", "#" %></li>
+                <li><%= link_to "新規投稿", new_post_path %></li>
               </ul>
           </details>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :posts, only: %i[index new create show]
+  resources :posts, only: %i[index new create show edit update]
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/20
## やったこと
- 投稿用フォームのパーシャル化
- 投稿編集機能の実装

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- 投稿詳細画面から編集ボタンをタップすると投稿編集ができるようになった

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他