### PR TITLE
add: #22 地図上で投稿一覧の表示

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,4 +1,5 @@
 class MapsController < ApplicationController
+  skip_before_action :require_login, only: %i[index]
   def index
     @posts = Post.includes(:user).order(created_at: :desc)
   end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,5 @@
+class MapsController < ApplicationController
+  def index
+    @posts = Post.includes(:user).order(created_at: :desc)
+  end
+end

--- a/app/decorators/map_decorator.rb
+++ b/app/decorators/map_decorator.rb
@@ -1,0 +1,13 @@
+class MapDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,0 +1,33 @@
+<div id="map" class="h-[37.5rem] w-full"></div>
+<script>
+    function initMap() {
+    // デフォルトポジション（東京周辺）の定義
+    const defaultlocation = { lat: 35.6803997, lng: 139.7690174 };
+
+    // 地図要所の取得
+    const mapElement = document.getElementById('map');
+
+    // 初期表示の設定
+    const mapOptions = {
+        center: defaultlocation,
+        zoom: 10,
+    }
+
+    const map = new google.maps.Map(mapElement, mapOptions);
+
+
+    //投稿が存在するかで条件分岐
+    <% if @posts.present? %>
+    // 投稿一覧を地図上で表示
+        <% @posts.each do |post| %>
+            new google.maps.Marker({
+                position: { lat: <%= post.latitude %>, lng: <%= post.longitude %> },
+                map: map,
+            });
+        <% end %>
+    <% else %>
+        console.log('投稿が存在しません');
+    <% end %>
+    }
+</script>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&callback=initMap"></script>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -17,7 +17,7 @@
             </summary>
               <ul class="p-2 bg-base-200 rounded-t-none z-50">
                 <li><%= link_to "一覧で探す", posts_path %></li>
-                <li><%= link_to "マップで探す", "#" %></li>
+                <li><%= link_to "マップで探す", maps_path %></li>
               </ul>
           </details>
         </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
             </summary>
               <ul class="p-2 bg-base-200 rounded-t-none z-50">
                 <li><%= link_to "一覧で探す", posts_path %></li>
-                <li><%= link_to "マップで探す", "#" %></li>
+                <li><%= link_to "マップで探す", maps_path %></li>
                 <li><%= link_to "新規投稿", new_post_path %></li>
               </ul>
           </details>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -13,24 +13,3 @@
     </div>
   </div>
 </div>
-<div id='map'></div>
-
-<style>
-#map{
-  height: 600px;
-  width: 100%
-}
-</style>
-
-<script>
-  const defaultlocation = { lat: 35.6803997, lng: 139.7690174 };
-
-  function initMap(){
-
-    map = new google.maps.Map(document.getElementById('map'),{
-      center: defaultlocation,
-      zoom: 10
-    });
-  }
-</script>
-<script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&callback=initMap"></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resources :posts
+  resources :maps, only: %i[index]
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/22
## やったこと
- ログイン前後ともに地図上で投稿一覧のピンが表示できるようになった
- ヘッターの地図一覧から投稿した場所の一覧がピンで表示される

## できなかったこと・やらなかったこと
- JSの部分の書き分け（一旦html.erbにスクリプトタグで記載しています）

## できるようになること（ユーザ目線）
- 投稿した場所一覧が地図上で表示できる。

## できなくなること（ユーザ目線）


## 動作確認
- デプロイして動作確認済み

## その他
- 投稿がない場合の条件分岐については地図上での検索機能のissueで対応予定(#29)