### PR TITLE
add: #60 タグづけ機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,7 +10,7 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params)
-    if @post.save
+    if @post.save_with_tags(tag_names: params.dig(:post, :tag_names).split(',').uniq)
       redirect_to posts_path, success: '投稿に成功しました'
     else
       flash.now[:alert] = '投稿に失敗しました'
@@ -28,7 +28,8 @@ class PostsController < ApplicationController
 
   def update
     @post = current_user.posts.find(params[:id])
-    if @post.update(post_params)
+    pp post_params
+    if @post.save_with_tags(tag_names: params.dig(:post, :tag_names).split(',').uniq)
       redirect_to post_path(post_params), success: '投稿の更新に成功しました'
     else
       flash.now[:alert] = '投稿の更新に失敗しました'

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -18,4 +18,19 @@ class Post < ApplicationRecord
   # geocodingについての設定
   geocoded_by :address
   before_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }
+
+  def save_with_tags(tag_names:)
+    ActiveRecord::Base.transaction do
+      self.tags = tag_names.map { |name| Tag.find_or_initialize_by(name: name.strip) }
+      save!
+    end
+    true
+  rescue StandardError
+    false
+  end
+
+  def tag_names
+    # NOTE: pluckだと新規作成失敗時に値が残らない(返り値がnilになる)
+    tags.map(&:name).join(',')
+  end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -11,10 +11,11 @@
     <%= f.label :address, '住所', class: 'label w-full md:w-1/2 mx-auto' %>
     <%= f.text_field :address, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto', id: 'address' %>
 
-
-
     <%= f.label :body, 'おすすめポイント', class: 'label w-full md:w-1/2 mx-auto' %>
     <%= f.text_area :body, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto h-auto', rows: 5, placeholder: 'おすすめメニューや感想などを入力しましょう' %>
+
+    <%= f.label :tag_names, 'タグ',class: 'label w-full md:w-1/2 mx-auto'  %>
+    <%= f.text_field :tag_names, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto', placeholder: ',で区切って入力してください' %>
 
     <%= f.label :amount, '使った金額(任意)', class: 'label w-full md:w-1/2 mx-auto' %>
     <div class='mx-auto w-full md:w-1/2 text-center'>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/60
## やったこと
- タグづけ機能の実装
- タグ編集機能の実装
- 共通のものは保存されないように設定

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- 投稿にタグづけできるようになった
- すでにした投稿に対してタグの編集ができるようになった

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他