### PR TITLE
Bugfix/update posts with tags

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
+  before_action :set_post, only: %i[edit update destroy]
   def index
     posts = if (tag_name = params[:tag_name])
       Post.with_tag(tag_name)
@@ -27,13 +28,10 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
-  def edit
-    @post = current_user.posts.find(params[:id])
-  end
+  def edit;end
 
   def update
-    @post = current_user.posts.find(params[:id])
-    pp post_params
+    @post.assign_attributes(post_params)
     if @post.save_with_tags(tag_names: params.dig(:post, :tag_names).split(',').uniq)
       redirect_to post_path(post_params), success: '投稿の更新に成功しました'
     else
@@ -43,7 +41,6 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    @post = current_user.posts.find(params[:id])
     @post.destroy!
     redirect_to posts_path, success: '投稿を削除しました'
   end
@@ -51,5 +48,9 @@ class PostsController < ApplicationController
   private
     def post_params
       params.require(:post).permit(:genre, :restaurant_name, :address, :body, :amount)
+    end
+
+    def set_post
+      @post = current_user.posts.find(params[:id])
     end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,8 +6,6 @@ class Post < ApplicationRecord
   validates :restaurant_name, presence: true, length: {maximum: 255}
   validates :address, presence: true
   validates :body, presence: true, length: {maximum: 65_535 }
-  validates :latitude, presence: true
-  validates :longitude, presence: true
   validates :genre, presence: true
 
   enum genre: { japanese_food: 0, chinese_food: 1, western_food: 2, korean_food: 3, ethnic_food: 4,
@@ -19,7 +17,7 @@ class Post < ApplicationRecord
 
   # geocodingについての設定
   geocoded_by :address
-  before_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }
+  after_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }
 
   def save_with_tags(tag_names:)
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
## issue番号

## やったこと
- 投稿の更新が正しくできなかったため、`@post.assign_attributes(post_params)`の記載を追加
- `:geocode`の設定を`after_validation`に変更（未入力の事項があっても`:geocode`が発動されてしまうため）

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- 投稿の更新

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で新規投稿と投稿更新の動作確認済み

## その他