### PR TITLE
add: #33 MVPレビュー前の修正（タグ表示の乱れ、投稿一覧の文字数）

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -17,8 +17,8 @@
             </div>
             <%= link_to post.restaurant_name, post_path(post), class: "font-black text-gray-800 md:text-2xl text-xl" %>
             <p class="md:text-base text-gray-500 text-sm">住所：<%= post.address %></p>
-            <p class="md:text-lg text-gray-600 text-base"><%= post.body %></p>
-            <div class='flex justify-left'>
+            <p class="md:text-lg text-gray-600 text-base"><%= post.body.truncate(50) %></p>
+            <div class='flex justify-left flex-wrap'>
                 <%= render post.tags %>
             </div>
         </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
                 <%= @post.restaurant_name %>
             </h1>
         </div>
-        <div class="flex justify-center">
+        <div class="flex justify-center flex-wrap">
             <%= render @post.tags %>
         </div>
         <p class='w-full mx-auto p-5'>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,1 +1,1 @@
-<%= link_to tag.name, posts_path(tag_name: tag.name), class: 'badge badge-ghost badge-lg mr-1' %>
+<%= link_to tag.name, posts_path(tag_name: tag.name), class: 'badge badge-ghost badge-base mr-1 mt-1' %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class='container'>
     <div class= 'text-center mt-6'>
-        <h1 class='text-2xl font-semi-bold'>ログイン</h1>
+        <h1 class='text-2xl font-semibold'>ログイン</h1>
     </div>
 
     <%= form_with url: login_path do |f| %>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/33
## やったこと
- 一覧画面の本文のワード数制限
- タグが増えたらしたに回るようにした

## できなかったこと・やらなかったこと
- モックアップの設定

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で実施済み

## その他