### PR TITLE
add #73 フォーム入力時エラーの詳細表示

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_with model: post do |f| %>
+<%= render 'shared/error_messages', model: f.object %>
+
     <%= f.label :genre, '料理のジャンル', class: 'label w-full md:w-1/2 mx-auto' %>
     <div class='mx-auto w-full md:w-1/2 text-center'>
         <%= f.select :genre, Post.enum_options_for_select(:genre), { include_blank: "未選択" },

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -12,9 +12,7 @@
         </li>
         <li>
           <details>
-            <summary>
-              <%= link_to "メニュー" %>
-            </summary>
+            <summary>メニュー</summary>
               <ul class="p-2 bg-base-200 rounded-t-none z-50">
                 <li><%= link_to "一覧で探す", posts_path %></li>
                 <li><%= link_to "マップで探す", maps_path %></li>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,11 @@
+<% if model.errors.any? %>
+    <div id = "error_explanation" class= "alert alert-error my-6 w-full md:w-1/2 mx-auto">
+        <ul class="mb-0 text-white">
+            <% model.errors.full_messages.each do |message|%>
+                <li>
+                    <%= message %>
+                </li>
+            <% end %>
+        </ul>
+    </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,9 +12,7 @@
         </li>
         <li>
           <details>
-            <summary>
-              <%= link_to "メニュー" %>
-            </summary>
+            <summary>メニュー</summary>
               <ul class="p-2 bg-base-200 rounded-t-none z-50">
                 <li><%= link_to "一覧で探す", posts_path %></li>
                 <li><%= link_to "マップで探す", maps_path %></li>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,6 +3,7 @@
         <h1 class='text-2xl font-semibold'>ユーザー登録</h1>
     </div>
     <%= form_with model: @user do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
 
         <%= f.label :name, class: 'label w-full md:w-1/2 mx-auto'%>
         <%= f.text_field :name, class: 'input input-bordered input-accent form-control mb-6 w-full md:w-1/2 mx-auto' %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -35,3 +35,4 @@ ja:
         tag_names: タグ
         post_images: 写真（3枚まで）
         amount: 使った金額(任意)
+        genre: ジャンル


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/73

## やったこと
- ユーザー新規作成、新規投稿作成、投稿編集の際に入力エラーの詳細が表示されるようになった

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他
-  herokuのアップデート実施（Warning: heroku update available from 9.0.0 to 9.1.0.）