### PR TITLE
add: #77 本番環境でのパスワードリセット関係の設定

### DIFF
--- a/app/decorators/password_reset_decorator.rb
+++ b/app/decorators/password_reset_decorator.rb
@@ -9,5 +9,4 @@ class PasswordResetDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,4 @@
 class UserMailer < ApplicationMailer
-
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #
@@ -8,7 +7,7 @@ class UserMailer < ApplicationMailer
   def reset_password_email(user)
     @user = User.find(user.id)
     @url = edit_password_reset_url(@user.reset_password_token)
-      mail(to: user.email,
-        subject: 'パスワードリセットのお知らせ')
+    mail(to: user.email,
+         subject: 'パスワードリセットのお知らせ')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :name, presence: true, length: { maximum: 255 } # name要素を入力必須、255文字まで。
 
-
   has_many :posts
 
   def own?(object)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,18 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = Settings.default_url_options.to_h
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    port: 587,
+    address: 'smtp.gmail.com',
+    domain: 'gmail.com', #Gmailを使う場合
+    user_name: ENV['GMAIL_ADDRESS'], #Gmailアカウントのメールアドレス
+    password: ENV['GMAIL_PASSWORD'], #Gmailで設定したアプリパスワード
+  }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+default_url_options:
+  host: 'https://metime-meals-21937e9c3179.herokuapp.com/'


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/77
## やったこと
- 本番環境でパスワードリセットできるようGoogleアカウント作成
- アプリパスワードの発行
- 本番環境でのメール送信についての設定

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- パスワードのリセットができるようになった

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他
- [Action Mailer の基礎 - Railsガイド](https://railsguides.jp/action_mailer_basics.html#gmail%E7%94%A8%E3%81%AEaction-mailer%E8%A8%AD%E5%AE%9A)
- アプリパスワードのスペースは不要