### PR TITLE
#78 add: google認証についてのAPI設定・モジュール導入・設定

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,3 @@
+class Authentication < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
 
   has_many :posts
 
+  has_many :authentications, :dependent => :destroy
+  accepts_nested_attributes_for :authentications
+
   def own?(object)
     object.user_id == id
   end

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :external]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -80,7 +80,7 @@ Rails.application.config.sorcery.configure do |config|
   # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
   # Default: `[]`
   #
-  # config.external_providers =
+  config.external_providers = i%[google]
 
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
   # Path to ca_file. By default use a internal ca-bundle.crt.
@@ -158,10 +158,10 @@ Rails.application.config.sorcery.configure do |config|
   # config.auth0.callback_url = "https://0.0.0.0:3000/oauth/callback?provider=auth0"
   # config.auth0.site = "https://example.auth0.com"
   #
-  # config.google.key = ""
-  # config.google.secret = ""
-  # config.google.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=google"
-  # config.google.user_info_mapping = {:email => "email", :username => "name"}
+  config.google.key = ENV['GOOGLE_CLIENT_SECRET']
+  config.google.secret = ENV['GOOGLE_CLIENT_SECRET']
+  config.google.callback_url = "http://localhost:3000/google_login_api/callback"
+  config.google.user_info_mapping = {:email => "email", :name => "name"}
   # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
   #
   # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.
@@ -543,7 +543,7 @@ Rails.application.config.sorcery.configure do |config|
     # Class which holds the various external provider data for this user.
     # Default: `nil`
     #
-    # user.authentications_class =
+    user.authentications_class = Authentication
 
     # User's identifier in the `authentications` class.
     # Default: `:user_id`

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,4 @@
 default_url_options:
   host: 'localhost:3000'
+sorcery:
+  google_callback_url: 'http://localhost:3000/oauth/callback?provider=google'

--- a/db/migrate/20240807061009_sorcery_external.rb
+++ b/db/migrate/20240807061009_sorcery_external.rb
@@ -1,0 +1,12 @@
+class SorceryExternal < ActiveRecord::Migration[7.1]
+  def change
+    create_table :authentications do |t|
+      t.integer :user_id, null: false
+      t.string :provider, :uid, null: false
+
+      t.timestamps              null: false
+    end
+
+    add_index :authentications, [:provider, :uid]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_05_115129) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_07_061009) do
+  create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "restaurant_name", null: false
     t.string "address", null: false


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/78
## やったこと
- Google APIの設定・認証キーの取得
- SorceryのサブモジュールExternalの導入・モデルの追加
- config/initializers/sorcery.rbの設定
- config/settings/development.ymlでローカル環境でのリダイレクト先の指定

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 設定のみなので動作確認は未実施

## その他