### PR TITLE
Feature/#86 add post photos preview

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import './preview_post_images.js'

--- a/app/javascript/preview_post_images.js
+++ b/app/javascript/preview_post_images.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', function() {
+    let postImagesInput = document.getElementById('post-images-input');
+    let previewImages = document.getElementById('preview-post-images');
+
+    postImagesInput.addEventListener('change', function(event) {
+        // 新しい画像が選択された場合、既存のプレビュー画像を消す
+        previewImages.innerHTML = '';
+
+        let files = event.target.files;
+
+        for (let i = 0; i < files.length; i++) {
+            let file = files[i];
+            let reader = new FileReader();
+
+            reader.onload = function(e) {
+                let img = document.createElement('img');
+                img.src = e.target.result;
+                img.classList.add("w-1/3", "h-auto", "object-contain", "m-2");
+                previewImages.appendChild(img);
+            }
+
+            reader.readAsDataURL(file);
+        }
+    });
+});

--- a/app/javascript/preview_post_images.js
+++ b/app/javascript/preview_post_images.js
@@ -3,7 +3,6 @@ document.addEventListener('turbo:load', function() {
     let previewImages = document.getElementById('preview-post-images');
 
     if (!postImagesInput) {
-        console.error('No element found with ID "post-images-input"');
         return;
     }
 
@@ -13,7 +12,6 @@ document.addEventListener('turbo:load', function() {
         let files = event.target.files;
 
         if (files.length === 0) {
-            console.warn('No files selected.');
             return;
         }
 
@@ -26,11 +24,10 @@ document.addEventListener('turbo:load', function() {
                 img.src = e.target.result;
                 img.classList.add("w-1/3", "h-auto", "object-contain", "m-2");
                 previewImages.appendChild(img);
-                console.log('Image loaded:', e.target.result);
             }
 
             reader.onerror = function(e) {
-                console.error('Error reading file:', file.name);
+                 // 何かエラーハンドリングが必要な場合はここに追加
             }
 
             reader.readAsDataURL(file);

--- a/app/javascript/preview_post_images.js
+++ b/app/javascript/preview_post_images.js
@@ -1,12 +1,21 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('turbo:load', function() {
     let postImagesInput = document.getElementById('post-images-input');
     let previewImages = document.getElementById('preview-post-images');
 
+    if (!postImagesInput) {
+        console.error('No element found with ID "post-images-input"');
+        return;
+    }
+
     postImagesInput.addEventListener('change', function(event) {
-        // 新しい画像が選択された場合、既存のプレビュー画像を消す
         previewImages.innerHTML = '';
 
         let files = event.target.files;
+
+        if (files.length === 0) {
+            console.warn('No files selected.');
+            return;
+        }
 
         for (let i = 0; i < files.length; i++) {
             let file = files[i];
@@ -17,6 +26,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 img.src = e.target.result;
                 img.classList.add("w-1/3", "h-auto", "object-contain", "m-2");
                 previewImages.appendChild(img);
+                console.log('Image loaded:', e.target.result);
+            }
+
+            reader.onerror = function(e) {
+                console.error('Error reading file:', file.name);
             }
 
             reader.readAsDataURL(file);

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -30,9 +30,18 @@
     <%= f.label :tag_names,class: 'label w-full md:w-1/2 mx-auto' %>
     <%= f.text_field :tag_names, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto', placeholder: ',で区切って入力してください' %>
 
-    <%= f.label :post_images, class: 'label w-full md:w-1/2 mx-auto'%>
-    <%= f.file_field :post_images, multiple: true,include_hidden: false, class: 'file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto'%>
-    <%= f.hidden_field :post_images_cache %>
+    <div>
+      <%= f.label :post_images, class: 'label w-full md:w-1/2 mx-auto'%>
+      <%= f.file_field :post_images, multiple: true, id: 'post-images-input', include_hidden: false, class: 'file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto'%>
+    </div>
+
+    <div id="preview-post-images" class="flex flex-wrap justify-center">
+      <% if post.post_images.present? %>
+        <% post.post_images.each do |image| %>
+          <%= image_tag image.to_s, class: "w-1/3 h-auto object-contain m-2" %>
+        <% end %>
+      <% end %>
+    </div>
 
     <%= f.label :amount, class: 'label w-full md:w-1/2 mx-auto' %>
     <div class='mx-auto w-full md:w-1/2 text-center'>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/86
## やったこと
- app/javascript/preview_post_images.jsを追加し、新規投稿時、投稿編集で画像を選択した際プレビューが表示されるようになった
- 投稿編集時ですでに投稿済みの画像がある場合、その画像が確認できる

## できなかったこと・やらなかったこと
- 一旦キャッシュに関しては保留
  - 複数画像の場合、hidden_fieldでキャッシュを指定するだけでは保持されなかった
  - 本リリース後、可能であれば実装予定

## できるようになること（ユーザ目線）
- 投稿予定の画像プレビューが確認できる

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境にて動作確認済み

## その他
- `addEventListener`の引数を`turbo:load`に変更したところ本番環境でも問題なく動作