### PR TITLE
add: #98 タグのレコメンド機能の実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import './preview_post_images.js'
+import './tags.js'

--- a/app/javascript/tags.js
+++ b/app/javascript/tags.js
@@ -1,0 +1,23 @@
+//turbo:loadに変更
+document.addEventListener('turbo:load', () => {
+
+    // テキストボックスを取得
+    const tagInput = document.querySelector('input[name="post[tag_names]"]');
+  
+    // タグをクリックした時の処理
+    const tagLinks = document.querySelectorAll('.tag-link');
+    tagLinks.forEach(link => {
+      link.addEventListener('click', (e) => {
+        // リンクのデフォルト動作を無効化
+        e.preventDefault();
+        // テキストボックスの内容にタグを追加
+        const clickedTag = e.target.innerText.trim();
+        if (tagInput.value) {
+          tagInput.value = `${tagInput.value},${clickedTag}`;
+        } else {
+          tagInput.value = `${clickedTag}`;
+        }
+      });
+    });
+  
+  });

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -29,6 +29,15 @@
 
     <%= f.label :tag_names,class: 'label w-full md:w-1/2 mx-auto' %>
     <%= f.text_field :tag_names, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto', placeholder: ',で区切って入力してください' %>
+    <div class="flex justify-center flex-wrap">
+      <%= link_to '券売機', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>
+      <%= link_to 'カウンター', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>
+      <%= link_to 'スマホ注文', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>
+      <%= link_to 'タブレット注文', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>
+      <%= link_to '1人用メニュー', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>
+      <%= link_to '静か', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>
+      <%= link_to '広々', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>
+    </div>
 
     <div>
       <%= f.label :post_images, class: 'label w-full md:w-1/2 mx-auto'%>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/98
## やったこと
- 1人用外食でおすすめポイントとなるタグを表示
- タップするとカンマ付きでフォームに追加できる

## できなかったこと・やらなかったこと
- 料理ジャンルごとのタグの表示分け
- パーシャルファイルでの切り分け

## できるようになること（ユーザ目線）
- おひとり様外食におすすめのタグをタップのみで投稿できるようになった

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境での動作確認済み

## その他