### PR TITLE
Feature/#87 投稿更新時のローディング画面作成

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,4 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import './preview_post_images.js'
 import './tags.js'
+import './modal.js'

--- a/app/javascript/modal.js
+++ b/app/javascript/modal.js
@@ -1,0 +1,14 @@
+document.addEventListener('turbo:load', function() {
+    const submitButton = document.getElementById('submit-button');
+  
+    submitButton.addEventListener('click', function(event) {
+      event.preventDefault(); // デフォルトの送信を防止
+      submitButton.disabled = true; // ボタンを無効化
+      document.getElementById('loading-modal').classList.remove('hidden'); // モーダルを表示
+  
+      // 少し遅延させてフォームを送信
+      setTimeout(function() {
+        submitButton.form.submit();
+      }, 100); // 100ミリ秒遅延させる
+    });
+  });

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -59,7 +59,10 @@
     </div>
 
     <div class='mx-auto md:w-1/2'>
-        <%= f.submit '投稿', class: 'btn btn-primary w-full my-6' %>
+        <%= f.submit '投稿', class: 'btn btn-primary w-full my-6', id: "submit-button"%>
+    </div>
+    <div id="loading-modal" class="hidden fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <%= render 'shared/modal'%>
     </div>
 <% end %>
 <div class='text-center mb-6'>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,4 +1,6 @@
 <div class="bg-white p-6 rounded shadow-lg text-center">
-    <div class="text-lg">送信中...</div>
-    <div class="mt-2 loading loading-dots loading-lg"></div>
+    <div class="flex justify-center">
+        <div class="animate-spin h-10 w-10 border-4 border-blue-500 rounded-full border-t-transparent"></div>
+    </div>
+    <div class="text-lg mt-2">送信中...</div>
 </div>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,0 +1,4 @@
+      <div class="bg-white p-6 rounded shadow-lg text-center">
+    <div class="text-lg">送信中...</div>
+    <div class="mt-2 loading loading-spinner loading-lg"></div>
+</div>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,4 +1,4 @@
-      <div class="bg-white p-6 rounded shadow-lg text-center">
+<div class="bg-white p-6 rounded shadow-lg text-center">
     <div class="text-lg">送信中...</div>
-    <div class="mt-2 loading loading-spinner loading-lg"></div>
+    <div class="mt-2 loading loading-dots loading-lg"></div>
 </div>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/87
## やったこと
- Javascriptで更新時に「送信中」のローディングモーダルが表示できるようになった
- モーダル内部はアバター設定時にも使用予定なのでshared配下にパーシャルで切り分けた

## できなかったこと・やらなかったこと
- Stimulusは使用せず

## できるようになること（ユーザ目線）
- 新規投稿・投稿編集の際、投稿ボタンをクリックすると更新中のモーダルが表示される

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境での動作確認済み

## その他
- アニメーションについてdaisyUIのコンポーネントで最初実装していたが、本番環境でスマホでの動作確認をしたところアニメーションがうまく動かなかった。
- そのため、TailwindCSSで直接書いた下記のアニメーションを利用したところ問題なく表示できたためこちらで実装しました
- [Tailwind CSSでお手軽ローディングアニメーション](https://zenn.dev/catnose99/articles/19a05103ab9ec7)