### PR TITLE
Feature/#36 add maps current location

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <%= stylesheet_link_tag 'https://fonts.googleapis.com/icon?family=Material+Icons', media: 'all'%>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-K5HPRJCQX8"></script>
     <script>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,3 +1,4 @@
+<div><button id="current-location-button" class="btn btn-primary">現在地を取得する</button></div>
 <div id="map" class="h-[37.5rem] w-full"></div>
 <%# モーダルを表示する要素 %>
 <dialog id="post_modal" class="modal modal-bottom sm:modal-middle">
@@ -9,6 +10,7 @@
     </div>
 </dialog>
 <script>
+    let map, infoWindow;
     function initMap() {
     // デフォルトポジション（東京周辺）の定義
     const defaultlocation = { lat: 35.6803997, lng: 139.7690174 };
@@ -23,6 +25,37 @@
     }
 
     const map = new google.maps.Map(mapElement, mapOptions);
+    infoWindow = new google.maps.InfoWindow();
+
+    // 位置情報取得用のボタンの定義
+    const locationButton = document.getElementById("current-location-button");
+    locationButton.classList.add("custom-map-control-button");
+    map.controls[google.maps.ControlPosition.TOP_CENTER].push(locationButton);
+
+    locationButton.addEventListener("click", () => {
+      // 現在地を取得
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            const pos = {
+              lat: position.coords.latitude,
+              lng: position.coords.longitude,
+            };
+
+            infoWindow.setPosition(pos);
+            infoWindow.setContent("現在地が取得できました");
+            infoWindow.open(map);
+            map.setCenter(pos);
+          },
+          () => {
+            handleLocationError(true, infoWindow, map.getCenter());
+          }
+        );
+      } else {
+        // ブラウザがGeolocationをサポートしていない場合
+        handleLocationError(false, infoWindow, map.getCenter());
+      }
+    });
 
 
     //投稿が存在するかで条件分岐
@@ -61,5 +94,18 @@
         console.log('投稿が存在しません');
     <% end %>
     }
+    
+  // 取得できなかった時の処理
+  function handleLocationError(browserHasGeolocation, infoWindow, pos) {
+    infoWindow.setPosition(pos);
+    infoWindow.setContent(
+      browserHasGeolocation
+        ? "現在地の取得に失敗しました"
+        : "このブラウザは位置情報に対応していません"
+    );
+    infoWindow.open(map);
+  }
+
+  window.initMap = initMap;
 </script>
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&callback=initMap"></script>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -47,6 +47,7 @@
             const pos = {
               lat: position.coords.latitude,
               lng: position.coords.longitude,
+              zoom: 15,
             };
 
             infoWindow.setPosition(pos);

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,5 +1,12 @@
-<div><button id="current-location-button" class="btn btn-primary">現在地を取得する</button></div>
+<div>
+    <div>
+    <button id="current-location-button" class="btn btn-primary text-left">
+        <span class="material-icons">location_on</span>
+        <span class="block text-sm">現在地を取得する</span>
+    </button>
+    </div>
 <div id="map" class="h-[37.5rem] w-full"></div>
+</div>
 <%# モーダルを表示する要素 %>
 <dialog id="post_modal" class="modal modal-bottom sm:modal-middle">
     <div class="modal-box">
@@ -53,6 +60,7 @@
         );
       } else {
         // ブラウザがGeolocationをサポートしていない場合
+        alert('このブラウザは位置情報に対応していません');
         handleLocationError(false, infoWindow, map.getCenter());
       }
     });
@@ -97,6 +105,7 @@
     
   // 取得できなかった時の処理
   function handleLocationError(browserHasGeolocation, infoWindow, pos) {
+    alert('位置情報の取得に失敗しました。');
     infoWindow.setPosition(pos);
     infoWindow.setContent(
       browserHasGeolocation

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -28,7 +28,7 @@
     // 初期表示の設定
     const mapOptions = {
         center: defaultlocation,
-        zoom: 10,
+        zoom: 14,
     }
 
     const map = new google.maps.Map(mapElement, mapOptions);
@@ -47,7 +47,6 @@
             const pos = {
               lat: position.coords.latitude,
               lng: position.coords.longitude,
-              zoom: 15,
             };
 
             infoWindow.setPosition(pos);


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/36
## やったこと
- 地図上の「現在地を取得する」ボタンをタップするとブラウザの位置情報を取得してフォーカスする
- zoomのデフォルト値を変更（ユーザーの使用ケースとして近隣の飲食店を探すことが多いと考えたため）
- Googleアイコンの導入

## できなかったこと・やらなかったこと
- 以前技術検証した際のコードを転用して不要なコードがありそうだがリファクタリングはできてません
- Google Mapの表示と若干かぶっている箇所はMapのissue #84 で実装します

## できるようになること（ユーザ目線）
- 地図上の「現在地を取得する」ボタンをタップすると現在地周辺にフォーカスする

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他