### PR TITLE
Feature/#85 add show request referer

### DIFF
--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -86,8 +86,9 @@
             <div class='text-lg font-semibold'><%= post.restaurant_name %></div>
             <p><%= post.address %></p>
             <div class="flex justify-center mt-3">
-                <div class="badge badge-lg mr-1">タグ</div>
-                <div class="badge badge-lg mr-1">タグ</div>
+                <% post.tags.each do |tag| %>
+                  <div class="badge badge-ghost badge-base mr-1 mt-1"><%= tag.name %></div>
+                <% end %>
             </div>
         </div>
             <p>おすすめポイント<br><%= post.body %></p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,17 @@
 <div class='container rounded-xl shadow-xl p-6 max-w-xs md:max-w-3xl mx-auto my-10 border border-white bg-base-100'>
     <div class='ml-6 mt-6'>
+    <% if request.referer.present? %>
+        <% referer_path = URI(request.referer).path %>
+        <% if referer_path == maps_path %>
+            <%= link_to '＜戻る', maps_path  %>
+        <% elsif referer_path == mypage_posts_path %>
+            <%= link_to '＜戻る', mypage_posts_path  %>
+        <% else %>
+            <%= link_to '＜戻る', posts_path  %>
+        <% end %>
+    <% else %>
         <%= link_to '＜戻る', posts_path  %>
+    <% end %>
     </div>
     <div class='md:w-1/2 mx-auto'>
         <div class='text-center mt-6'>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/85
## やったこと
- 投稿詳細画面から「戻る」ボタンをタップすると一つ前に表示されていた画面に戻るようになった
- 地図一覧をタップした際表示されるモーダルにタグが表示されるようになった

## できなかったこと・やらなかったこと
- 地図一覧表示の際発生するN+1問題に関しては https://github.com/nakayama-bird/metime-meals/issues/99 で対応予定

## できるようになること（ユーザ目線）
- 投稿詳細画面で「戻る」をタップすると前に表示されていた画面に遷移するようになった
- 前に表示していた画面がない際は、カード一覧に遷移するようになった
- 地図一覧のモーダルでタグが表示されるようになった

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他