### PR TITLE
add: #99 一覧画面のN+1問題の対策、デバックツール導入、タグの個数制限

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,8 +83,13 @@ group :development, :test do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec'
 
-# rspec
+  # rspec
   gem 'rspec-rails', '~> 6.1.0'
+
+  # debug
+  gem 'pry-byebug'
+  gem 'pry-rails'
+
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -122,6 +123,7 @@ GEM
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
     childprocess (5.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.3.3)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -235,6 +237,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0702)
@@ -288,6 +291,14 @@ GEM
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.1.2)
       stringio
     public_suffix (6.0.0)
@@ -466,6 +477,8 @@ DEPENDENCIES
   kaminari
   letter_opener_web (~> 3.0)
   mysql2 (~> 0.5)
+  pry-byebug
+  pry-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n (~> 7.0.0)

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -2,7 +2,7 @@ class MapsController < ApplicationController
   skip_before_action :require_login, only: %i[index search]
   before_action :set_search_posts_form
   def index
-    @posts = Post.includes(:user).order(created_at: :desc)
+    @posts = Post.includes(:user, :tags).order(created_at: :desc)
   end
 
   def search

--- a/app/controllers/mypage/posts_controller.rb
+++ b/app/controllers/mypage/posts_controller.rb
@@ -1,5 +1,5 @@
 class Mypage::PostsController < ApplicationController
   def index
-    @posts = Post.includes(:user).where(user_id: current_user.id).order(created_at: :desc)
+    @posts = Post.includes(:user, :tags).where(user_id: current_user.id).order(created_at: :desc)
   end
 end

--- a/app/controllers/mypage/posts_controller.rb
+++ b/app/controllers/mypage/posts_controller.rb
@@ -1,5 +1,5 @@
 class Mypage::PostsController < ApplicationController
   def index
-    @posts = Post.includes(:user, :tags).where(user_id: current_user.id).order(created_at: :desc)
+    @posts = Post.includes(:user, :tags).where(user_id: current_user.id).order(created_at: :desc).page params[:page]
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,9 +4,9 @@ class PostsController < ApplicationController
   before_action :set_search_posts_form
   def index
     posts = if (tag_name = params[:tag_name])
-              Post.with_tag(tag_name)
+              Post.preload(:tags).with_tag(tag_name)
             else
-              Post.includes(:user)
+              Post.includes(:tags, :user)
             end
     @posts = posts.order(created_at: :desc).page params[:page]
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,6 +17,7 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params)
+    # digメソッドでネストしたハッシュを参照する
     if @post.save_with_tags(tag_names: params.dig(:post, :tag_names).split(',').uniq)
       redirect_to posts_path, success: '投稿に成功しました'
     else

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -36,6 +36,7 @@ class Post < ApplicationRecord
     false
   end
 
+  # 編集時デフォルトで表示するためのメソッド
   def tag_names
     # NOTE: pluckだと新規作成失敗時に値が残らない(返り値がnilになる)
     tags.map(&:name).join(',')

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,8 +46,8 @@ class Post < ApplicationRecord
   private
 
   def validate_tag_count
-    return unless tags.size > 7 # 例えばタグが5個以上ならエラー
+    return unless tags.size > 5 # タグが5個以上ならエラー
 
-    errors.add(:tag_names, 'は7個以下にしてください')
+    errors.add(:tag_names, 'は5個以下にしてください')
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,7 @@ class Post < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535 }
   validates :genre, presence: true
   validates :post_images, length: { maximum: 3 }
+  before_validation :validate_tag_count
 
   enum genre: { japanese_food: 0, chinese_food: 1, western_food: 2, korean_food: 3, ethnic_food: 4,
                 ramen: 10, curry: 11, cafe: 20, bar: 21, other: 99 }
@@ -40,5 +41,13 @@ class Post < ApplicationRecord
   def tag_names
     # NOTE: pluckだと新規作成失敗時に値が残らない(返り値がnilになる)
     tags.map(&:name).join(',')
+  end
+
+  private
+
+  def validate_tag_count
+    return unless tags.size > 7 # 例えばタグが5個以上ならエラー
+
+    errors.add(:tag_names, 'は7個以下にしてください')
   end
 end

--- a/app/views/mypage/posts/index.html.erb
+++ b/app/views/mypage/posts/index.html.erb
@@ -10,4 +10,5 @@
             <div class= 'text-lg m-auto'>投稿はありません</div>
         <% end %>
     </div>
+    <%= paginate @posts %>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <%= f.label :tag_names,'タグ（7つまで）',class: 'label w-full md:w-1/2 mx-auto' %>
+    <%= f.label :tag_names,'タグ（5つまで）',class: 'label w-full md:w-1/2 mx-auto' %>
     <%= f.text_field :tag_names, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto', placeholder: ',で区切って入力してください' %>
     <div class="flex justify-center flex-wrap">
       <%= link_to '券売機', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <%= f.label :tag_names,class: 'label w-full md:w-1/2 mx-auto' %>
+    <%= f.label :tag_names,'タグ（7つまで）',class: 'label w-full md:w-1/2 mx-auto' %>
     <%= f.text_field :tag_names, class: 'input input-borderd input-accent form-control mb-6 w-full md:w-1/2 mx-auto', placeholder: ',で区切って入力してください' %>
     <div class="flex justify-center flex-wrap">
       <%= link_to '券売機', '#', class: 'tag-link badge badge-ghost badge-base mr-2 mt-2 mb-1' %>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/99
## やったこと
### 一覧画面のN+1問題の対策
#### カード一覧
![image](https://github.com/user-attachments/assets/7d75bf99-40ca-40e7-9d16-717784a99ae9)
#### マイページ
![image](https://github.com/user-attachments/assets/53ea223b-30ee-45a8-927f-f2fcdbf0bc76)
#### 地図
![image](https://github.com/user-attachments/assets/7194c5dc-fd68-480c-8a04-fb0c851d9cd6)
### タグの個数制限
- 投稿につけられるタグの個数を5個にした
- 目的：個数を制限することでより適切なタグをつけてもらえるだろうと考えたため、マジカルナンバー7 https://zenn.dev/link/comments/f77f3f5374ae9c
### デバックツールの導入
- タグ個数制限に際し、既存のコード確認のため`gem 'pry-byebug``'gem 'pry-rails'`を導入

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）
- タグの入力が5個までに制限された

## 動作確認
- 本番環境で動作確認済み

## その他
- [付けられるタグの個数を制限する(Ruby on Rails)計画⇒実証](https://zenn.dev/hirouen/articles/c4d276c7a6713a)