### PR TITLE
fix: #80 rubocop対応、不適切な画像を弾くよう設定

### DIFF
--- a/app/controllers/concerns/image_validatable.rb
+++ b/app/controllers/concerns/image_validatable.rb
@@ -1,0 +1,18 @@
+module ImageValidatable
+  extend ActiveSupport::Concern
+
+  def validate_images(images)
+    return true if images.blank? || images.all?(&:blank?)
+
+    inappropriate_images = identify_inappropriate_images(images)
+    inappropriate_images.empty?
+  end
+
+  private
+
+  def identify_inappropriate_images(images)
+    images.reject do |image|
+      Vision.image_analysis(image)
+    end
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,6 +2,7 @@ class PostsController < ApplicationController
   skip_before_action :require_login, only: %i[index show search]
   before_action :set_post, only: %i[edit update destroy]
   before_action :set_search_posts_form
+  include ImageValidatable
   def index
     posts = if (tag_name = params[:tag_name])
               Post.preload(:tags).with_tag(tag_name)
@@ -77,20 +78,5 @@ class PostsController < ApplicationController
 
   def search_post_params
     params.fetch(:q, {}).permit(:address_or_name, :genre_select)
-  end
-
-  def validate_images(post_images)
-    return true if post_images.blank? || post_images.all?(&:blank?)
-
-    inappropriate_images = []
-    post_images.each do |image|
-      result = Vision.image_analysis(image)
-      inappropriate_images << image unless result
-    end
-    if inappropriate_images.any?
-      return false
-    end
-
-    true
   end
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/80
## やったこと
- Cloud Vision APIを使用した不適切画像の判定機能の実装
- 画像判定のためのロジックをpostコントローラではなく、concernに実装（実装するかは未定だが、アバターなど他の画像投稿の際にも使用できるようにするため）

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）
- 不適切な画像が投稿された場合、「不適切な画像が含まれています」とフラッシュメッセージが表示されて投稿できなくなった

## 動作確認
- 本番環境で動作確認済み

## その他