### PR TITLE
add: #125 画像のプレビューを新しく投稿する際のみ表示、投稿失敗したら削除

### DIFF
--- a/app/javascript/preview_post_images.js
+++ b/app/javascript/preview_post_images.js
@@ -27,10 +27,15 @@ document.addEventListener('turbo:load', function() {
             }
 
             reader.onerror = function(e) {
-                 // 何かエラーハンドリングが必要な場合はここに追加
+                // 何かエラーハンドリングが必要な場合はここに追加
             }
 
             reader.readAsDataURL(file);
         }
     });
+
+    // エラーメッセージ表示後に空にする
+    // if (document.getElementById('error_explanation')) {
+    //     previewImages.innerHTML = '';
+    // }
 });

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -44,13 +44,7 @@
       <%= f.file_field :post_images, multiple: true, id: 'post-images-input', include_hidden: false, class: 'file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto'%>
     </div>
 
-    <div id="preview-post-images" class="flex flex-wrap justify-center">
-      <% if post.post_images.present? %>
-        <% post.post_images.each do |image| %>
-          <%= image_tag image.to_s, class: "w-1/3 h-auto object-contain m-2" %>
-        <% end %>
-      <% end %>
-    </div>
+    <div id="preview-post-images" class="flex flex-wrap justify-center"></div>
 
     <%= f.label :amount, class: 'label w-full md:w-1/2 mx-auto' %>
     <div class='mx-auto w-full md:w-1/2 text-center'>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/125
## やったこと
- 投稿に失敗した際、プレビューが表示されなくなった
- すでに投稿済みの写真についてもプレビューが表示されなくなった

## できなかったこと・やらなかったこと
- 複数画像のキャッシュは一旦断念しました

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）
- 投稿編集時に既存の画像が確認できなくなる（こちらもややこしくなるため、これから投稿しようとしているものに表示を絞りました）

## 動作確認
- 本番環境での動作確認済み

## その他
- carrierwaveのcacheについて勉強したいです