### PR TITLE
add: #24 ブックマーク機能の実装/非同期化/Postモデルの変更/詳細画面のMapのzoom値変更

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,13 @@
+class BookmarksController < ApplicationController
+  def create
+    post = Post.find(params[:post_id])
+    current_user.bookmark(post)
+    redirect_to request.referer, success: "投稿をお気に入りしました"
+  end
+
+  def destroy
+    post = current_user.bookmarks.find(params[:id]).post
+    current_user.unbookmark(post)
+    redirect_to request.referer, success: "投稿のお気に入りを解除しました", status: :see_other
+  end
+end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -2,12 +2,12 @@ class BookmarksController < ApplicationController
   def create
     post = Post.find(params[:post_id])
     current_user.bookmark(post)
-    redirect_to request.referer, success: "投稿をお気に入りしました"
+    redirect_to request.referer, success: '投稿をお気に入りしました'
   end
 
   def destroy
     post = current_user.bookmarks.find(params[:id]).post
     current_user.unbookmark(post)
-    redirect_to request.referer, success: "投稿のお気に入りを解除しました", status: :see_other
+    redirect_to request.referer, success: '投稿のお気に入りを解除しました', status: :see_other
   end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,13 +1,11 @@
 class BookmarksController < ApplicationController
   def create
-    post = Post.find(params[:post_id])
-    current_user.bookmark(post)
-    redirect_to request.referer, success: '投稿をお気に入りしました'
+    @post = Post.find(params[:post_id])
+    current_user.bookmark(@post)
   end
 
   def destroy
-    post = current_user.bookmarks.find(params[:id]).post
-    current_user.unbookmark(post)
-    redirect_to request.referer, success: '投稿のお気に入りを解除しました', status: :see_other
+    @post = current_user.bookmarks.find(params[:id]).post
+    current_user.unbookmark(@post)
   end
 end

--- a/app/decorators/bookmark_decorator.rb
+++ b/app/decorators/bookmark_decorator.rb
@@ -9,5 +9,4 @@ class BookmarkDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/decorators/bookmark_decorator.rb
+++ b/app/decorators/bookmark_decorator.rb
@@ -1,0 +1,13 @@
+class BookmarkDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,4 @@
+class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,6 +4,7 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
+  has_many :bookmarks, dependent: :destroy
 
   validates :restaurant_name, presence: true, length: { maximum: 255 }
   validates :address, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,23 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
 
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_posts, through: :bookmarks, source: :post
+
   def own?(object)
     object.user_id == id
   end
+
+  def bookmark(post)
+    bookmark_posts << post
+  end
+
+  def unbookmark(post)
+    bookmark_posts.destroy(post)
+  end
+
+  def bookmark?(post)
+    bookmark_posts.include?(post)
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,5 +32,4 @@ class User < ApplicationRecord
   def bookmark?(post)
     bookmark_posts.include?(post)
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :name, presence: true, length: { maximum: 255 } # name要素を入力必須、255文字まで。
 
-  has_many :posts
+  has_many :posts, dependent: :destroy
 
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bookmark-button-for-post-#{@post.id}" do %>
+  <%= render 'posts/unbookmark', post: @post %>
+<% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unbookmark-button-for-post-#{@post.id}" do %>
+  <%= render 'posts/bookmark', post: @post %>
+<% end %>

--- a/app/views/posts/_bookmark.html.erb
+++ b/app/views/posts/_bookmark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
+  <span class="material-icons">bookmark_border</span>
+<% end %>

--- a/app/views/posts/_bookmark.html.erb
+++ b/app/views/posts/_bookmark.html.erb
@@ -1,3 +1,3 @@
 <%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
-  <span class="material-icons">bookmark_border</span>
+  <span class="material-icons ">bookmark_border</span>
 <% end %>

--- a/app/views/posts/_bookmark_buttons.html.erb
+++ b/app/views/posts/_bookmark_buttons.html.erb
@@ -1,0 +1,7 @@
+<div class='ms-auto'>
+  <% if current_user.bookmark?(post) %>
+    <%= render 'unbookmark', { post: post } %>
+  <% else %>
+    <%= render 'bookmark', { post: post } %>
+  <% end %>
+</div>

--- a/app/views/posts/_unbookmark.html.erb
+++ b/app/views/posts/_unbookmark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
+  <span class="material-icons">bookmark</span>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -13,6 +13,11 @@
         <%= link_to '＜戻る', posts_path  %>
     <% end %>
     </div>
+        <% if logged_in? %>
+    <div class='grid grid-cols-3 grid-cols-8 mt-10'>
+        <div class='ml-5 col-start-7'><%= render 'bookmark_buttons', { post: @post } %></div>
+    </div>
+    <% end %>
     <div class='md:w-1/2 mx-auto'>
         <div class='text-center mt-6'>
             <h2 class='text-base mb-2 font-medium'>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -110,7 +110,7 @@
 
     const mapOptions = {
         center: { lat: <%= @post.latitude %>, lng: <%= @post.longitude %> },
-        zoom: 16,
+        zoom: 15,
         disableDefaultUI: true,
     };
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :posts do
     collection do
-      get :search
+      get :search, :bookmarks
     end
   end
   resources :password_resets, only: %i[new create edit update]
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
   namespace :mypage do
     resources :posts, only: %i[index]
   end
+
+  resources :bookmarks, only: %i[create destroy]
 
   post "oauth/callback" => "oauths#callback"
   get "oauth/callback" => "oauths#callback"

--- a/db/migrate/20240831074531_create_bookmarks.rb
+++ b/db/migrate/20240831074531_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, foreign_key: true
+      t.references :post, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :bookmarks, [:user_id, :post_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_133941) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_31_074531) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -18,6 +18,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_133941) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
+  create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_bookmarks_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -68,6 +78,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_133941) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "taggings", "posts"
   add_foreign_key "taggings", "tags"


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/24
## やったこと
### ブックマーク関連
- Bookmarkモデルを作成
- Bookmarkコントローラを作成しcreate,destroyアクションを定義
- ブックマーク表示用のビューファイルを実装
- turbo_streamを使用した非同期化
- 一覧表示用のルーティングの設定
### ユーザーモデル関連
- has_many :postsにdependent: :destroyを追加
### 詳細画面の地図について
-  zoomが近すぎて気になったためzoomの値を変更
## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- お気に入りの投稿を詳細画面でブックマークできるようになる
- ユーザー登録を削除すると投稿も合わせて削除される

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境での動作確認済み

## その他