### PR TITLE
add: #26 ブックマーク一覧の追加、マイページにタブ追加

### DIFF
--- a/app/controllers/mypage/bookmark_posts_controller.rb
+++ b/app/controllers/mypage/bookmark_posts_controller.rb
@@ -1,0 +1,5 @@
+class Mypage::BookmarkPostsController < ApplicationController
+  def index
+    @posts = current_user.bookmark_posts.includes(:user, :tags).order(created_at: :desc).page(params[:page])
+  end
+end

--- a/app/decorators/mypage/bookmark_post_decorator.rb
+++ b/app/decorators/mypage/bookmark_post_decorator.rb
@@ -1,0 +1,12 @@
+class Mypage::BookmarkPostDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/views/mypage/bookmark_posts/_post.html.erb
+++ b/app/views/mypage/bookmark_posts/_post.html.erb
@@ -1,0 +1,32 @@
+<div class='container'>
+    <div class="relative flex flex-col mb-5 md:flex-row md:space-x-5 space-y-3 md:space-y-0 rounded-xl shadow-lg p-3 max-w-xs md:max-w-3xl mx-auto border border-white bg-white" >
+        <% if post.post_images.present? %>
+            <div class="w-full md:w-1/3 bg-white grid place-items-center">
+                <%= image_tag post.post_images.first.to_s, class: 'object-contain w-72 h-72' %>
+            </div>
+            <% else %>
+            <div class="w-full md:w-1/3 bg-white grid place-items-center">
+                <%= image_tag 'placeholder.png' , class: 'object-contain w-72 h-72' %>
+            </div>
+        <% end %>
+        <div class="w-full md:w-2/3 bg-white flex flex-col space-y-2 p-3">
+            <div class="flex justify-between item-center">
+                <div class="flex items-center">
+                    <p class="text-gray-600 font-bold text-sm ml-1"><%= post.human_attribute_enum(:genre) %></p>
+                </div>
+            </div>
+            <%= link_to post.restaurant_name, post_path(post), class: "font-black text-gray-800 md:text-2xl text-xl" %>
+            <p class="md:text-base text-gray-500 text-sm">住所：<%= post.address %></p>
+            <p class="md:text-lg text-gray-600 text-base"><%= post.body.truncate(50) %></p>
+            <div class='flex justify-left flex-wrap'>
+                <%= render post.tags %> 
+            </div>
+            <div class="flex items-center">
+                <svg class="w-4 h-4 text-yellow-300 me-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 22 20">
+                    <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
+                </svg>
+                <p class="mr-2 text-sm font-bold"><%= post.rating_before_type_cast + 1 %></p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/mypage/bookmark_posts/index.html.erb
+++ b/app/views/mypage/bookmark_posts/index.html.erb
@@ -2,8 +2,8 @@
     <div class='text-center mt-6 font-bold text-3xl'>マイページ📓</div>
     <div class='text-center mt-6'>
         <div role="tablist" class="tabs tabs-boxed">
-            <%= link_to "マイポスト", mypage_posts_path, role: "tab", class: "tab tab-active" %>
-            <%= link_to "お気に入り", mypage_bookmark_posts_path, role: "tab", class: "tab" %>
+            <%= link_to "マイポスト", mypage_posts_path, role: "tab", class: "tab" %>
+            <%= link_to "お気に入り", mypage_bookmark_posts_path, role: "tab", class: "tab tab-active" %>
             <%= link_to "設定", "#", role: "tab", class: "tab" %>
         </div>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,8 +4,10 @@
         <% referer_path = URI(request.referer).path %>
         <% if referer_path == maps_path %>
             <%= link_to '＜戻る', maps_path  %>
-        <% elsif referer_path == mypage_posts_path %>
+        <% elsif referer_path == mypage_posts_path  %>
             <%= link_to '＜戻る', mypage_posts_path  %>
+        <% elsif referer_path == mypage_bookmark_posts_path  %>
+            <%= link_to '＜戻る', mypage_bookmark_posts_path  %>
         <% else %>
             <%= link_to '＜戻る', posts_path  %>
         <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
                 <li><%= link_to "一覧で探す", posts_path %></li>
                 <li><%= link_to "マップで探す", maps_path, data: { turbo: false } %></li>
                 <li><%= link_to "新規投稿", new_post_path %></li>
-                <li><%= link_to "マイページ", mypage_posts_path %></li>
+                <li><%= link_to "マイページ", mypage_bookmark_posts_path %></li>
               </ul>
           </details>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :posts do
     collection do
-      get :search, :bookmarks
+      get :search
     end
   end
   resources :password_resets, only: %i[new create edit update]
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   namespace :mypage do
     resources :posts, only: %i[index]
+    resources :bookmark_posts, only: [:index]
   end
 
   resources :bookmarks, only: %i[create destroy]


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/26
## やったこと
### ブックマーク一覧
- mypage/bookmark_postsで自分がブックマークした投稿の一覧が確認できるようになった
### マイページ表示
- タブで「マイポスト」「お気に入り」「設定」で切り替えられるようになった
- ヘッダーの「マイページからのアクセス先を「お気に入り」ページに変更

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- 自分がブックマークした投稿一覧をマイページで確認できる

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他