### PR TITLE
add: #96 Userモデルにageとgenderを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,9 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_posts, through: :bookmarks, source: :post
 
+  enum gender: { male: 0, female: 1 }
+  enum age: { teens: 0, twenties: 1, thirties: 2, forties: 3, fifties: 4, over_sixties: 5 }
+
   def own?(object)
     object.user_id == id
   end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,6 +23,16 @@ ja:
         four_thousand_level: 4000円台
         five_thousand_level: 5000円台
         more_than_six_thousand: 6000円以上
+      user/gender:
+        male: 男性
+        female: 女性
+      user/age:
+        teens: 10代
+        twenties: 20代
+        thirties: 30代
+        forties: 40代
+        fifties: 50代
+        over_sixties: 60代以上
       user:
         email: メールアドレス
         name: 名前

--- a/db/migrate/20240902051449_add_gender_and_age_to_users.rb
+++ b/db/migrate/20240902051449_add_gender_and_age_to_users.rb
@@ -1,0 +1,6 @@
+class AddGenderAndAgeToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :gender, :integer
+    add_column :users, :age, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_02_040441) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_02_051449) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -75,6 +75,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_040441) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.string "avatar"
+    t.integer "gender"
+    t.integer "age"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/96
## やったこと
- Postモデルにage、genderカラムを追加
- どちらもenumを作成（[ER図](https://dbdiagram.io/d/metimez_meals-668689079939893dae0b800b)）
- config/locales/ja.ymlで日本語設定

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- カラムの追加enumの設定のみなので実施せず
- #97 も含めて本番環境でのマイグレーション済み
```
== 20240902040441 AddAvatarToUsers: migrating =================================
-- add_column(:users, :avatar, :string)
   -> 0.3779s
== 20240902040441 AddAvatarToUsers: migrated (0.3780s) ========================

I, [2024-09-02T07:22:27.586218 #2]  INFO -- : Migrating to AddGenderAndAgeToUsers (20240902051449)
== 20240902051449 AddGenderAndAgeToUsers: migrating ===========================
-- add_column(:users, :gender, :integer)
   -> 0.0557s
-- add_column(:users, :age, :integer)
   -> 0.0713s
== 20240902051449 AddGenderAndAgeToUsers: migrated (0.1271s) ==================
```

## その他