### PR TITLE
fix: モデルにenumにしている箇所でdefaultを設定していない箇所のattributeを設定

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,8 @@
 class Post < ApplicationRecord
   mount_uploaders :post_images, PostImageUploader
 
+  attribute :amount, :integer
+
   belongs_to :user
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   mount_uploader :avatar, AvatarUploader
+  attribute :gender, :integer
+  attribute :age, :integer
 
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] } # パスワードは6文字以上
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }


### PR DESCRIPTION
## 課題
- ローカル環境でログアウトしたところ下記エラー
```
Completed 500 Internal Server Error in 15ms (ActiveRecord: 0.0ms | Allocations: 8160)
web-1  | 16:26:52 web.1  | 
web-1  | 16:26:52 web.1  | 
web-1  | 16:26:52 web.1  |   
web-1  | 16:26:52 web.1  | RuntimeError (Undeclared attribute type for enum 'gender'. Enums must be backed by a database column or declared with an explicit type via `attribute`.):
```

## やったこと
- [Rails 7.1 - can't define enums for attributes which don't exist in table · Issue #49717 · rails/rails](https://github.com/rails/rails/issues/49717)
- [タイトル: 「Rails 7.0.1 から 7.1.2 にアップグレードした後、列挙型 'screen\_location' の未宣言属性型エラー」 - Stack Overflow](https://stackoverflow.com/questions/77820337/title-undeclared-attribute-type-error-for-enum-screen-location-after-rails-u)
- 同様のエラーに対し、enumで設定している箇所をモデルにattirbuteで明示することで解決するとあったのでそちらで対応
- Userのgenderとageに加えて、Postのamountに関しても同様に設定

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 本番環境でユーザー登録、投稿、ログアウトまで問題なく動作すること確認済み。

## その他