### PR TITLE
add: #134 アイコン表示乱れの改善、アイコン登録時モーダル

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
-import './preview_post_images.js'
+import './preview_images.js'
 import './tags.js'
 import './modal.js'

--- a/app/javascript/preview_images.js
+++ b/app/javascript/preview_images.js
@@ -1,12 +1,12 @@
 document.addEventListener('turbo:load', function() {
-    let postImagesInput = document.getElementById('post-images-input');
-    let previewImages = document.getElementById('preview-post-images');
+    let imagesInput = document.getElementById('images-input');
+    let previewImages = document.getElementById('preview-images');
 
-    if (!postImagesInput) {
+    if (!imagesInput) {
         return;
     }
 
-    postImagesInput.addEventListener('change', function(event) {
+    imagesInput.addEventListener('change', function(event) {
         previewImages.innerHTML = '';
 
         let files = event.target.files;

--- a/app/views/mypage/profiles/edit.html.erb
+++ b/app/views/mypage/profiles/edit.html.erb
@@ -25,13 +25,17 @@
 
         <div>
             <%= f.label :avatar, class: 'label w-full md:w-1/2 mx-auto'%>
-            <%= f.file_field :avatar,  id: 'post-images-input',  class: 'file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto'%>
+            <%= f.file_field :avatar,  id: 'images-input',  class: 'file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto'%>
         </div>
 
-        <div id="preview-post-images" class="flex flex-wrap justify-center"></div>
+        <div id="preview-images" class="flex flex-wrap justify-center"></div>
 
         <div class='mx-auto md:w-1/2'>
-            <%= f.submit '登録', class: 'btn btn-primary w-full mt-6 mb-6 mx-auto' %>
+            <%= f.submit '登録', class: 'btn btn-primary w-full mt-6 mb-6 mx-auto', id: "submit-button" %>
+        </div>
+
+        <div id="loading-modal" class="hidden fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+            <%= render 'shared/modal'%>
         </div>
     <% end %>
 </div>

--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -12,42 +12,41 @@
         <div>
             <div class="bg-white relative shadow rounded-lg w-5/6 md:w-5/6 lg:w-4/6 xl:w-3/6 mx-auto">
                 <div class="flex justify-center">
-                    <%= image_tag current_user.avatar_url, class: "rounded-full mx-auto absolute -top-16 w-24 h-24 shadow-md border-4 border-white transition duration-200 transform" %>
-
+                    <%= image_tag current_user.avatar_url, class: "rounded-full mx-auto absolute sm:-top-16 -top-12 w-24 h-24 shadow-md border-4 border-white transition duration-200 transform" %>
                 </div>
-                <div class="mt-12"> 
+                <div class="mt-20 md:mt-16"> 
                     <h1 class="font-bold text-center text-2xl text-gray-900"><%= current_user.name %></h1> 
-                    <div class="my-4 px-4">
-                        <%= link_to "ユーザー情報更新", edit_mypage_profiles_path, class: "btn btn-primary block rounded-lg text-center font-bold leading-8 px-4 py-2" %>
-                    </div>
+                </div>
+                <div class="my-4 px-4">
+                    <%= link_to "ユーザー情報更新", edit_mypage_profiles_path, class: "btn btn-primary block rounded-lg text-center font-bold leading-8 px-4 py-2" %>
+                </div>
 
-                    <div class="w-full">
-                        <div class="mt-4 w-full flex flex-col items-center overflow-hidden text-sm"> 
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                                <span class="material-icons mr-2">person</span>
-                                <%= current_user.name %>
-                            </a>
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                                <span class="material-icons mr-2">mail_outline</span>
-                                <%= current_user.email %>
-                            </a>
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                                <span class="material-icons mr-2">
-                                    <%= if current_user.gender.present?
-                                        current_user.gender == "male" ? "man" : "woman"
-                                    else
-                                        "help_outline"
-                                    end %>
-                                </span>
-                                <%= current_user.gender ? current_user.human_attribute_enum(:gender) : "回答なし" %>
-                            </a>
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                                <span class="material-icons mr-2">
-                                    <%= current_user.age ? "numbers" : "help_outline" %>
-                                </span>
-                                <%= current_user.age ? current_user.human_attribute_enum(:age) : "回答なし" %>
-                            </a>
-                        </div>
+                <div class="w-full">
+                    <div class="mt-4 w-full flex flex-col items-center overflow-hidden text-sm"> 
+                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                            <span class="material-icons mr-2">person</span>
+                            <%= current_user.name %>
+                        </a>
+                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                            <span class="material-icons mr-2">mail_outline</span>
+                            <%= current_user.email %>
+                        </a>
+                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                            <span class="material-icons mr-2">
+                                <%= if current_user.gender.present?
+                                    current_user.gender == "male" ? "man" : "woman"
+                                else
+                                    "help_outline"
+                                end %>
+                            </span>
+                            <%= current_user.gender ? current_user.human_attribute_enum(:gender) : "回答なし" %>
+                        </a>
+                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                            <span class="material-icons mr-2">
+                                <%= current_user.age ? "numbers" : "help_outline" %>
+                            </span>
+                            <%= current_user.age ? current_user.human_attribute_enum(:age) : "回答なし" %>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -12,7 +12,7 @@
         <div>
             <div class="bg-white relative shadow rounded-lg w-5/6 md:w-5/6 lg:w-4/6 xl:w-3/6 mx-auto">
                 <div class="flex justify-center">
-                    <%= image_tag current_user.avatar_url, class: "rounded-full mx-auto absolute -top-16 w-24 h-24 shadow-md border-4 border-white transition duration-200 transform hover:scale-110" %>
+                    <%= image_tag current_user.avatar_url, class: "rounded-full mx-auto absolute -top-16 w-24 h-24 shadow-md border-4 border-white transition duration-200 transform" %>
 
                 </div>
                 <div class="mt-12"> 
@@ -23,15 +23,15 @@
 
                     <div class="w-full">
                         <div class="mt-4 w-full flex flex-col items-center overflow-hidden text-sm"> 
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block hover:bg-gray-100 transition duration-150 flex items-center"> <!-- py-4 から py-3、pl-6 から pl-4、pr-3 から pr-2 に変更して余白を縮小 -->
+                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
                                 <span class="material-icons mr-2">person</span>
                                 <%= current_user.name %>
                             </a>
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block hover:bg-gray-100 transition duration-150 flex items-center"> <!-- py-4 から py-3、pl-6 から pl-4、pr-3 から pr-2 に変更して余白を縮小 -->
+                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
                                 <span class="material-icons mr-2">mail_outline</span>
                                 <%= current_user.email %>
                             </a>
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block hover:bg-gray-100 transition duration-150 flex items-center"> <!-- py-4 から py-3、pl-6 から pl-4、pr-3 から pr-2 に変更して余白を縮小 -->
+                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
                                 <span class="material-icons mr-2">
                                     <%= if current_user.gender.present?
                                         current_user.gender == "male" ? "man" : "woman"
@@ -41,7 +41,7 @@
                                 </span>
                                 <%= current_user.gender ? current_user.human_attribute_enum(:gender) : "回答なし" %>
                             </a>
-                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block hover:bg-gray-100 transition duration-150 flex items-center"> <!-- py-4 から py-3、pl-6 から pl-4、pr-3 から pr-2 に変更して余白を縮小 -->
+                            <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
                                 <span class="material-icons mr-2">
                                     <%= current_user.age ? "numbers" : "help_outline" %>
                                 </span>

--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -9,45 +9,41 @@
     </div>
 
     <div class="container mx-auto my-20"> 
-        <div>
-            <div class="bg-white relative shadow rounded-lg w-5/6 md:w-5/6 lg:w-4/6 xl:w-3/6 mx-auto">
-                <div class="flex justify-center">
-                    <%= image_tag current_user.avatar_url, class: "rounded-full mx-auto absolute sm:-top-16 -top-12 w-24 h-24 shadow-md border-4 border-white transition duration-200 transform" %>
-                </div>
-                <div class="mt-20 md:mt-16"> 
-                    <h1 class="font-bold text-center text-2xl text-gray-900"><%= current_user.name %></h1> 
-                </div>
-                <div class="my-4 px-4">
-                    <%= link_to "ユーザー情報更新", edit_mypage_profiles_path, class: "btn btn-primary block rounded-lg text-center font-bold leading-8 px-4 py-2" %>
-                </div>
+        <div class="bg-white relative shadow rounded-lg w-5/6 md:w-5/6 lg:w-4/6 xl:w-3/6 mx-auto">
+            <div class="flex flex-col items-center">
+                <%= image_tag current_user.avatar_url, class: "rounded-full w-24 h-24 shadow-md border-4 border-white transition duration-200 transform -mt-12 md:-mt-16" %>
+                <h1 class="font-bold text-center text-2xl text-gray-900 mt-4 md:mt-8"><%= current_user.name %></h1>
+            </div>
+            <div class="my-4 px-4">
+                <%= link_to "ユーザー情報更新", edit_mypage_profiles_path, class: "btn btn-primary block rounded-lg text-center font-bold leading-8 px-4 py-2" %>
+            </div>
 
-                <div class="w-full">
-                    <div class="mt-4 w-full flex flex-col items-center overflow-hidden text-sm"> 
-                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                            <span class="material-icons mr-2">person</span>
-                            <%= current_user.name %>
-                        </a>
-                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                            <span class="material-icons mr-2">mail_outline</span>
-                            <%= current_user.email %>
-                        </a>
-                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                            <span class="material-icons mr-2">
-                                <%= if current_user.gender.present?
-                                    current_user.gender == "male" ? "man" : "woman"
-                                else
-                                    "help_outline"
-                                end %>
-                            </span>
-                            <%= current_user.gender ? current_user.human_attribute_enum(:gender) : "回答なし" %>
-                        </a>
-                        <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
-                            <span class="material-icons mr-2">
-                                <%= current_user.age ? "numbers" : "help_outline" %>
-                            </span>
-                            <%= current_user.age ? current_user.human_attribute_enum(:age) : "回答なし" %>
-                        </a>
-                    </div>
+            <div class="w-full">
+                <div class="mt-4 w-full flex flex-col items-center overflow-hidden text-sm"> 
+                    <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                        <span class="material-icons mr-2">person</span>
+                        <%= current_user.name %>
+                    </a>
+                    <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                        <span class="material-icons mr-2">mail_outline</span>
+                        <%= current_user.email %>
+                    </a>
+                    <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                        <span class="material-icons mr-2">
+                            <%= if current_user.gender.present?
+                                current_user.gender == "male" ? "man" : "woman"
+                            else
+                                "help_outline"
+                            end %>
+                        </span>
+                        <%= current_user.gender ? current_user.human_attribute_enum(:gender) : "回答なし" %>
+                    </a>
+                    <a class="w-full border-t border-gray-100 text-gray-600 py-3 pl-4 pr-2 w-full block transition duration-150 flex items-center"> 
+                        <span class="material-icons mr-2">
+                            <%= current_user.age ? "numbers" : "help_outline" %>
+                        </span>
+                        <%= current_user.age ? current_user.human_attribute_enum(:age) : "回答なし" %>
+                    </a>
                 </div>
             </div>
         </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -41,10 +41,10 @@
 
     <div>
       <%= f.label :post_images, class: 'label w-full md:w-1/2 mx-auto'%>
-      <%= f.file_field :post_images, multiple: true, id: 'post-images-input', include_hidden: false, class: 'file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto'%>
+      <%= f.file_field :post_images, multiple: true, id: 'images-input', include_hidden: false, class: 'file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto'%>
     </div>
 
-    <div id="preview-post-images" class="flex flex-wrap justify-center"></div>
+    <div id="preview-images" class="flex flex-wrap justify-center"></div>
 
     <%= f.label :amount, class: 'label w-full md:w-1/2 mx-auto' %>
     <div class='mx-auto w-full md:w-1/2 text-center'>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -101,7 +101,7 @@
     <div class="flex flex-col md:flex-row items-center md:space-x-4">
 
         <!-- ユーザーアイコン -->
-        <%= image_tag @post.user.avatar.url, class: "rounded-full w-16 h-16 shadow-md border-4 border-white transition duration-200 hover:scale-110" %>
+        <%= image_tag @post.user.avatar.url, class: "rounded-full w-16 h-16 shadow-md border-4 border-white transition duration-200" %>
 
         <!-- ユーザー情報を縦に並べる -->
         <div class="flex flex-col space-y-2 mt-4 md:mt-0">


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/134
## やったこと
- プロフィールページのスマホでのレイアウト崩れ改善
- アバター登録時の「送信中」モーダル表示
- 写真プレビューのJSファイルの名称変更（アバターにも使用しているため）

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
-アバター登録時にローディングアニメーションが表示される

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他