### PR TITLE
add: #93 独自ドメイン設定に伴う変更

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,4 +1,4 @@
 default_url_options:
-  host: 'https://metime-meals-21937e9c3179.herokuapp.com/'
+  host: 'https://www.metime-meals.com/'
 sorcery:
-  google_callback_url: 'https://metime-meals-21937e9c3179.herokuapp.com/oauth/callback?provider=google'
+  google_callback_url: 'https://www.metime-meals.com/oauth/callback?provider=google'


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/93
## やったこと
- 独自ドメインをMuuMuuで取得
- herokuで設定
- Googleログインの際のリダイレクト先を独自ドメインに変更

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他
- [カスタムドメインを設定する(Heroku) #Rails - Qiita](https://qiita.com/Daichi-appy/items/840c99cb6b4cf69f83a7)
- [[無料!]Herokuで独自ドメインをかんたんにSSL化させる | 未経験からWebエンジニアを目指す](https://osamudaira.com/461/)
- [【Render × MuuMuuDomain】独自ドメイン取得方法①](https://zenn.dev/s17w09/articles/31cc8a15817ff3)