### PR TITLE
add: #89 ボトムナビゲーション・ヘッターの修正

### DIFF
--- a/app/views/maps/_search_post_form.html.erb
+++ b/app/views/maps/_search_post_form.html.erb
@@ -1,16 +1,26 @@
-<%= form_with model: search_form, url: maps_path, scope: :q ,method: :get, data: { turbo: false },class: 'flex' do |f|%>
+<%= form_with model: search_form, url: maps_path, scope: :q ,method: :get, data: { turbo: false }, class: 'flex flex-wrap items-center' do |f| %>
+  <div class="w-full md:w-1/2 px-2 flex items-center">
     <%= f.search_field :address_or_name, 
         id: 'search_field_of_address_or_name',    
-        class: 'input input-borderd input-accent form-control mb-6 flex-auto md:w-1/2 mx-auto',
+        class: 'input input-bordered input-accent form-control mb-6 w-full h-12',
         placeholder: '店名・エリア' %>
-    <%= f.select :genre_select, Post.enum_options_for_select(:genre), { include_blank: "未選択" },
+  </div>
+  
+  <div class="w-full md:w-1/2 px-2 flex items-center">
+    <%= f.select :genre_select, Post.enum_options_for_select(:genre), { include_blank: "ジャンル未選択" },
         id: 'search_field_of_genre',
-        class: 'bg-card-body bg-base-100 rounded-3xl border border-accent py-2 px-3 mb-6 w-full md:w-1/2 mx-auto' %>
-        <%= f.hidden_field :map_center_lat, id: 'map_center_lat' %>
-        <%= f.hidden_field :map_center_lng, id: 'map_center_lng' %>
-    <%= f.submit '検索', class: 'btn btn-primary flex-auto' %>
-    <button type="button", id="form-reset-button" class="btn btn-secondary flex-auto">リセット</button>
+        class: 'bg-card-body bg-base-100 rounded-3xl border border-accent py-2 px-3 mb-6 w-full h-12' %>
+  </div>
+
+  <%= f.hidden_field :map_center_lat, id: 'map_center_lat' %>
+  <%= f.hidden_field :map_center_lng, id: 'map_center_lng' %>
+
+  <div class="w-full flex justify-between px-2">
+    <%= f.submit '検索', class: 'btn btn-primary flex-auto mr-2 mb-4' %>
+    <button type="button" id="form-reset-button" class="btn w-auto font-light mb-4">クリア</button>
+  </div>
 <% end %>
+
 <script>
 document.getElementById("form-reset-button").addEventListener("click", function() {
     // フィールドの値を空にする

--- a/app/views/posts/_search_post_form.html.erb
+++ b/app/views/posts/_search_post_form.html.erb
@@ -1,13 +1,24 @@
-<%= form_with model: search_form, url: search_posts_path, scope: :q, method: :get, class: 'flex', id: 'search_form' do |f| %>
+<%= form_with model: search_form, url: search_posts_path, scope: :q, method: :get, class: 'flex flex-wrap items-center', id: 'search_form' do |f| %>
+  <div class="w-full md:w-1/2 px-2 flex items-center">
     <%= f.search_field :address_or_name, 
         id: 'search_field_of_address_or_name',    
-        class: 'input input-borderd input-accent form-control mb-6 flex-auto md:w-1/2 mx-auto',
+        class: 'input input-bordered input-accent form-control mb-6 w-full h-12',
         placeholder: '店名・エリア' %>
-    <%= f.select :genre_select, Post.enum_options_for_select(:genre), { include_blank: "未選択" },
+  </div>
+  
+  <div class="w-full md:w-1/2 px-2 flex items-center">
+    <%= f.select :genre_select, Post.enum_options_for_select(:genre), { include_blank: "ジャンル未選択" },
         id: 'search_field_of_genre',
-        class: 'bg-card-body bg-base-100 rounded-3xl border border-accent py-2 px-3 mb-6 w-full md:w-1/2 mx-auto' %>
-    <%= f.submit '検索', class: 'btn btn-primary flex-auto' %>
-    <button type="button", id="form-reset-button" class="btn btn-secondary flex-auto">リセット</button>
+        class: 'bg-card-body bg-base-100 rounded-3xl border border-accent py-2 px-3 mb-6 w-full h-12' %>
+  </div>
+
+  <%= f.hidden_field :map_center_lat, id: 'map_center_lat' %>
+  <%= f.hidden_field :map_center_lng, id: 'map_center_lng' %>
+
+  <div class="w-full flex justify-between px-2">
+    <%= f.submit '検索', class: 'btn btn-primary flex-auto mr-2 mb-4' %>
+    <button type="button" id="form-reset-button" class="btn w-auto font-light mb-4">クリア</button>
+  </div>
 <% end %>
 
 <script>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,9 +1,6 @@
 <div class='container px-5 py24 mx-auto'>
     <div class='text-center mt-6'>
         <%= render 'search_post_form', search_form: @search_form %>
-        <% if logged_in? %>
-            <%= link_to '新規投稿', new_post_path, class: 'btn btn-accent btn-wide'%>
-        <% end %>
     </div>
     <div class="flex flex-wrap m-4">
         <% if @posts.present? %>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,9 +1,6 @@
 <div class='container px-5 py24 mx-auto'>
     <div class='text-center mt-6'>
         <%= render 'search_post_form', search_form: @search_form %>
-        <% if logged_in? %>
-            <%= link_to '新規投稿', new_post_path, class: 'btn btn-accent btn-wide'%>
-        <% end %>
     </div>
     <div class="flex flex-wrap m-4">
         <% if @posts.present? %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -13,8 +13,8 @@
         <li>
           <details>
             <summary>メニュー</summary>
-              <ul class="p-2 bg-base-200 rounded-t-none z-50">
-                <li><%= link_to "一覧で探す", posts_path %></li>
+              <ul class="absolute right-1 p-2 bg-base-200 rounded-t-none z-50 w-max">
+                <li><%= link_to "一覧で探す", posts_path, class: "mb-2" %></li>
                 <li><%= link_to "マップで探す", maps_path, data: { turbo: false } %></li>
               </ul>
           </details>
@@ -24,3 +24,45 @@
     </div>
   </div>
 </header>
+<div class="fixed z-50 w-full h-16 max-w-lg -translate-x-1/2 bg-base-200 border border-gray-200 rounded-full bottom-4 left-1/2 dark:bg-gray-700 dark:border-gray-600">
+    <div class="grid h-full max-w-lg grid-cols-5 mx-auto">
+
+        <%= link_to posts_path, data: { tooltip_target: "tooltip-home" }, class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+            </svg>
+            <span class="sr-only">一覧</span>
+        <% end %>
+
+        <%= link_to maps_path, data: { turbo: false }, class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
+            </svg>
+            <span class="sr-only">地図</span>
+        <% end %>
+
+        <div class="flex items-center justify-center">
+            <%= link_to new_post_path, class: "inline-flex items-center justify-center w-10 h-10 font-medium bg-primary rounded-full hover:bg-blue-700 group focus:ring-4 focus:ring-blue-300 focus:outline-none dark:focus:ring-blue-800" do%>
+                <svg class="w-4 h-4 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 18">
+                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 1v16M1 9h16"/>
+                </svg>
+                <span class="sr-only">新規投稿/span>
+            <% end %>
+        </div>
+
+         <%= link_to mypage_bookmark_posts_path, class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg class="w-5 h-5 mb-1 text-gray-500 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z"/>
+            </svg>
+            <span class="sr-only">マイページ</span>
+        <% end %>
+
+        <%= link_to login_path, class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15M12 9l3 3m0 0-3 3m3-3H2.25" />
+            </svg>
+            <span class="sr-only">ログイン</span>
+        <% end %>
+    </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer footer-center bg-base-300 tent-base-content p-4">
+<footer class="footer footer-center bg-base-100 tent-base-content p-4 mb-20">
   <nav class="grid grid-flow-col gap-4">
     <a class="link linkhover"></a>
     <%= link_to "お問い合わせ先", "#", class:"link link-hover" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,11 +13,11 @@
         <li>
           <details>
             <summary>メニュー</summary>
-              <ul class="p-2 bg-base-200 rounded-t-none z-50">
-                <li><%= link_to "一覧で探す", posts_path %></li>
-                <li><%= link_to "マップで探す", maps_path, data: { turbo: false } %></li>
-                <li><%= link_to "新規投稿", new_post_path %></li>
-                <li><%= link_to "マイページ", mypage_bookmark_posts_path %></li>
+              <ul class="absolute right-1 p-2 bg-base-200 rounded-t-none z-50 w-max">
+                <li><%= link_to "一覧で探す", posts_path, class: "mb-2" %></li>
+                <li><%= link_to "マップで探す", maps_path, data: { turbo: false },class: "mb-2"  %></li>
+                <li><%= link_to "新規投稿", new_post_path, class: "mb-2"  %></li>
+                <li><%= link_to "マイページ", mypage_bookmark_posts_path, class: "mb-2" %></li>
               </ul>
           </details>
         </li>
@@ -26,3 +26,46 @@
     </div>
   </div>
 </header>
+
+<div class="fixed z-50 w-full h-16 max-w-lg -translate-x-1/2 bg-base-200 border border-gray-200 rounded-full bottom-4 left-1/2 dark:bg-gray-700 dark:border-gray-600">
+    <div class="grid h-full max-w-lg grid-cols-5 mx-auto">
+
+        <%= link_to posts_path, data: { tooltip_target: "tooltip-home" }, class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+            </svg>
+            <span class="sr-only">一覧</span>
+        <% end %>
+
+        <%= link_to maps_path, data: { turbo: false }, class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
+            </svg>
+            <span class="sr-only">地図</span>
+        <% end %>
+
+        <div class="flex items-center justify-center">
+            <%= link_to new_post_path, class: "inline-flex items-center justify-center w-10 h-10 font-medium bg-primary rounded-full hover:bg-blue-700 group focus:ring-4 focus:ring-blue-300 focus:outline-none dark:focus:ring-blue-800" do%>
+                <svg class="w-4 h-4 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 18">
+                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 1v16M1 9h16"/>
+                </svg>
+                <span class="sr-only">新規投稿/span>
+            <% end %>
+        </div>
+
+         <%= link_to mypage_bookmark_posts_path, class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg class="w-5 h-5 mb-1 text-gray-500 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z"/>
+            </svg>
+            <span class="sr-only">マイページ</span>
+        <% end %>
+
+        <%= link_to logout_path, data: {turbo_method: :delete, turbo_confirm: 'ログアウトしてもよろしいですか？'} , class: "inline-flex flex-col items-center justify-center px-5 rounded-s-full hover:bg-gray-50 dark:hover:bg-gray-800 group" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
+            </svg>
+            <span class="sr-only">ログアウト</span>
+        <% end %>
+    </div>
+</div>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/89
## やったこと
- ボトムナビゲーションの追加（スマホ,タブレット,PCで共通の表示）
- ヘッターのプルダウンの文字列を改行なしで表示

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- ボトムナビゲーションでの操作が可能になる

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他
### コンポーネント
- [Tailwind CSS Bottom Navigation - Flowbite](https://flowbite.com/docs/components/bottom-navigation/)
### アイコン
- [Heroicons](https://heroicons.com/)