### PR TITLE
add: #142 各ページのタイトルを動的に出力する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,13 @@
 module ApplicationHelper
+  def page_title(title = '')
+    base_ttitle = 'Me Time Meals'
+    if title.empty?
+      base_ttitle
+    else
+      "#{title} | #{base_ttitle}"
+    end
+  end
+
   def flash_background_color(type)
     case type.to_sym # シンボルに変換
     when :success then 'bg-success'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class = data-theme="cupcake">
   <head>
-    <title>Myapp</title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('マップ') %>
 <div class='text-center mt-6'>
   <%= render 'search_post_form', search_form: @search_form %>
   <p id="latitude" data-value="<%= @map_center_lat %>"></p>

--- a/app/views/mypage/bookmark_posts/index.html.erb
+++ b/app/views/mypage/bookmark_posts/index.html.erb
@@ -1,10 +1,11 @@
+<% content_for :title, page_title('お気に入り') %>
 <div class='container px-5 py24 mx-auto'>
     <div class='text-center mt-4 font-bold text-3xl'>マイページ📓</div>
     <div class='text-center mt-6'>
         <div role="tablist" class="tabs tabs-boxed">
             <%= link_to "マイポスト", mypage_posts_path, role: "tab", class: "tab" %>
             <%= link_to "お気に入り", mypage_bookmark_posts_path, role: "tab", class: "tab tab-active" %>
-            <%= link_to "設定", mypage_profiles_path, role: "tab", class: "tab" %>
+            <%= link_to "プロフィール", mypage_profiles_path, role: "tab", class: "tab" %>
         </div>
     </div>
     <div class="flex flex-wrap m-4">

--- a/app/views/mypage/posts/index.html.erb
+++ b/app/views/mypage/posts/index.html.erb
@@ -1,10 +1,11 @@
+<% content_for :title, page_title('マイポスト') %>
 <div class='container px-5 py24 mx-auto'>
     <div class='text-center mt-4 font-bold text-3xl'>マイページ📓</div>
     <div class='text-center mt-6'>
         <div role="tablist" class="tabs tabs-boxed">
             <%= link_to "マイポスト", mypage_posts_path, role: "tab", class: "tab tab-active" %>
             <%= link_to "お気に入り", mypage_bookmark_posts_path, role: "tab", class: "tab" %>
-            <%= link_to "設定", mypage_profiles_path, role: "tab", class: "tab" %>
+            <%= link_to "プロフィール", mypage_profiles_path, role: "tab", class: "tab" %>
         </div>
     </div>
     <div class="flex flex-wrap m-4">

--- a/app/views/mypage/profiles/edit.html.erb
+++ b/app/views/mypage/profiles/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('プロフィール編集') %>
 <div class='container'>
     <div class='text-center mt-6'>
         <h1 class='text-2xl font-semibold'>ユーザー情報更新</h1>

--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -1,10 +1,11 @@
+<% content_for :title, page_title('プロフィール') %>
 <div class='container px-5 py24 mx-auto'>
     <div class='text-center mt-4 font-bold text-3xl'>マイページ📓</div>
     <div class='text-center mt-6'>
         <div role="tablist" class="tabs tabs-boxed">
             <%= link_to "マイポスト", mypage_posts_path, role: "tab", class: "tab" %>
             <%= link_to "お気に入り", mypage_bookmark_posts_path, role: "tab", class: "tab" %>
-            <%= link_to "設定", mypage_profiles_path, role: "tab", class: "tab tab-active" %>
+            <%= link_to "プロフィール", mypage_profiles_path, role: "tab", class: "tab tab-active" %>
         </div>
     </div>
 

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('パスワードリセット') %>
 <div class='container'>
     <div class= 'text-center mt-6'>
         <h1 class='text-2xl font-semibold'>パスワードリセット</h1>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('パスワードリセット申請') %>
 <div class='container'>
     <div class= 'text-center mt-6'>
         <h1 class='text-2xl font-semibold'>パスワードリセット申請</h1>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('投稿編集') %>
 <div class='container'>
     <div class='text-center mt-6'>
         <h1 class='text-2xl font-semibold'>投稿編集</h1>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('一覧') %>
 <div class='container px-5 py24 mx-auto'>
     <div class='text-center mt-6'>
         <%= render 'search_post_form', search_form: @search_form %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('新規投稿') %>
 <div class='container'>
     <div class='text-center mt-6'>
         <h1 class='text-2xl font-semibold mb-3'>新規投稿</h1>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('詳細') %>
 <div class='container rounded-xl shadow-xl p-6 max-w-xs md:max-w-3xl mx-auto my-10 border border-white bg-base-100'>
     <div class='ml-6 mt-6'>
     <% if request.referer.present? %>

--- a/app/views/staticpages/policy.html.erb
+++ b/app/views/staticpages/policy.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('プライバシーポリシー') %>
 <section class="container mx-auto p-4">
   <section>
     <h2 class="text-lg font-semibold mb-4">プライバシーポリシー</h2>

--- a/app/views/staticpages/term.html.erb
+++ b/app/views/staticpages/term.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('利用規約') %>
 <section class="container mx-auto p-4 mr-7">
   <h1 class="text-xl font-bold mb-6">利用規約</h1>
 

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('ログイン') %>
 <div class='container'>
     <div class= 'text-center mt-6'>
         <h1 class='text-2xl font-semibold'>ログイン</h1>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, page_title('新規登録') %>
 <div class='container'>
     <div class='text-center mt-6'>
         <h1 class='text-2xl font-semibold'>ユーザー登録</h1>


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/142
## やったこと
- 各ページのタイトルを動的に出力する

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- ページのタイトルを確認できる

## できなくなること（ユーザ目線）


## 動作確認
- 開発環境での動作確認済み

## その他