### PR TITLE
fix: 詳細ページの地図一覧に戻るlink_toにturbo:falseを設定

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,7 @@
     <% if request.referer.present? %>
         <% referer_path = URI(request.referer).path %>
         <% if referer_path == maps_path %>
-            <%= link_to '＜戻る', maps_path  %>
+            <%= link_to '＜戻る', maps_path, data: { turbo: false }  %>
         <% elsif referer_path == mypage_posts_path  %>
             <%= link_to '＜戻る', mypage_posts_path  %>
         <% elsif referer_path == mypage_bookmark_posts_path  %>


### PR DESCRIPTION
## issue番号

## やったこと
- 詳細ページから地図一覧に戻る際、正しく地図一覧が表示されないバグに対処
- showのmaps_pathでの分岐で`data: { turbo: false } `を指定しました

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）
- 地図表示からの投稿詳細ページの戻る際、地図一覧が表示される

## できなくなること（ユーザ目線）


## 動作確認
- 本番環境で動作確認済み

## その他