### PR TITLE
add: #162 Userのモデルスペック完了・メールアドレスのバリデーション追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :reset_password_token, uniqueness: true, allow_nil: true
 
-  validates :email, uniqueness: true
+  validates :email, uniqueness: true, presence: true
   validates :name, presence: true, length: { maximum: 255 } # name要素を入力必須、255文字まで。
 
   has_many :posts, dependent: :destroy

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it '名前、メールがあり、パスワードは3文字以上であれば有効であること' do
+    user = build(:user)
+    expect(user).to be_valid
+  end
+
+  it 'メールはユニークであること' do
+    user1 = create(:user)
+    user2 = build(:user)
+    user2.email = user1.email
+    user2.valid?
+    expect(user2.errors[:email]).to include('はすでに存在します')
+  end
+
+  it 'メールアドレス、名前は必須項目であること' do
+    user = build(:user)
+    user.email = nil
+    user.name = nil
+    user.valid?
+    expect(user.errors[:email]).to include('を入力してください')
+    expect(user.errors[:name]).to include('を入力してください')
+  end
+
+  it '名前は255文字以下であること' do
+    user = build(:user)
+    user.name = 'a' * 256
+    user.valid?
+    expect(user.errors[:name]).to include('は255文字以内で入力してください')
+  end
+
+  it '世代と性別が入力できること' do
+    user = build(:user)
+    user.age = (0..5).to_a.sample
+    user.gender = (0..1).to_a.sample
+    expect(user).to be_valid
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { 'Maru' }
+    sequence(:email) { |n| "user_#{n}@example.com" }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/162
## やったこと
- Userのモデルスペック完了
- EmailがDB上では`null:false`になっているのにモデルで`presence: true`になっていなかった箇所修正

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
Userモデル：84.62%
![image](https://github.com/user-attachments/assets/4f39622a-759d-451d-aa48-db692108acab)

## その他