### PR TITLE
add: #167 mainブランチ以外の場合でもテストを走るようにする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,6 @@ jobs:
   #     - name: Run rspec
   #       run: bundle exec rspec
 
-  jobs:
   rubocop:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: rubocop, deploy
 
 on:
   push:
+    branches-ignore:
+      - main
+  pull_request:
     branches:
       - main
   
@@ -45,6 +48,7 @@ jobs:
   #     - name: Run rspec
   #       run: bundle exec rspec
 
+  jobs:
   rubocop:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -61,6 +65,7 @@ jobs:
         run: bundle exec rubocop -a
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: rubocop
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/167
## やったこと
- Github Actionsをmainブランチにpushhする以外にも発動するようにした
- デプロイに関してはmainブランチの時のみ実行

## できなかったこと・やらなかったこと
- rubocopの規約は内容を確認しそのまま

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- ブランチからのpushでrubocopが動作している旨確認済み

## その他