### PR TITLE
fix: mainブランチにマージするタイミングで動かない箇所改善

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,11 +2,7 @@ name: rubocop, deploy
 
 on:
   push:
-    branches-ignore:
-      - main
-  pull_request:
     branches:
-      - main
   
 jobs:
   # rspec:


### PR DESCRIPTION
## issue番号

## やったこと
- メインブランチでGitHub Actionsが発動しない問題対策

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- push時のrubocopはできているのでmainにマージした際の動きをチェックする

## その他