### PR TITLE
add: #174 Postモデルスペックの追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,6 +12,7 @@ class Post < ApplicationRecord
   validates :address, presence: true
   validates :body, presence: true, length: { maximum: 65_535 }
   validates :genre, presence: true
+  validates :rating, presence: true
   validates :post_images, length: { maximum: 3 }
   before_validation :validate_tag_count
 

--- a/lib/vision.rb
+++ b/lib/vision.rb
@@ -13,6 +13,7 @@ module Vision
 
     private
 
+    # HTTP POSTリクエストを作成・送信
     def send_request(image_file)
       uri = URI.parse(api_url)
       request = Net::HTTP::Post.new(uri.request_uri)
@@ -28,6 +29,7 @@ module Vision
       "https://vision.googleapis.com/v1/images:annotate?key=#{ENV['GOOGLE_API_KEY']}"
     end
 
+    # リクエストボディの作成
     def build_request_body(image_file)
       base64_image = Base64.encode64(image_file.tempfile.read)
       {
@@ -47,6 +49,7 @@ module Vision
       raise error['message'] if error.present?
     end
 
+    # 結果の判定
     def safe_search_results(result)
       result_arr = result.dig('responses', 0, 'safeSearchAnnotation').values
       !(result_arr.include?('VERY_LIKELY') || result_arr.include?('LIKELY'))

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  context '全てのフィールドが有効な場合' do
+    it '有効であること' do
+      post = build(:post)
+      expect(post).to be_valid
+    end
+  end
+
+  context '店名が存在しない場合' do
+    it '無効であること' do
+      post = build(:post, restaurant_name: nil)
+      expect(post).to be_invalid
+      expect(post.errors[:restaurant_name]).to include('を入力してください')
+    end
+  end
+
+  context '本文が存在しない場合' do
+    it '無効であること' do
+      post = build(:post, body: nil)
+      expect(post).to be_invalid
+      expect(post.errors[:body]).to include('を入力してください')
+    end
+  end
+
+  context '店名が255文字以下の場合' do
+    it '有効であること' do
+      post = build(:post, restaurant_name: 'a' * 255)
+      expect(post).to be_valid
+    end
+  end
+
+  context '店名が256文字以上の場合' do
+    it '無効であること' do
+      post = build(:post, restaurant_name: 'a' * 256)
+      expect(post).to be_invalid
+      expect(post.errors[:restaurant_name]).to include('は255文字以内で入力してください')
+    end
+  end
+
+  context '本文が65535文字以内の場合' do
+    it '有効であること' do
+      post = build(:post, body: 'a' * 65535)
+      expect(post).to be_valid
+    end
+  end
+
+  context '本文が65536文字以上の場合' do
+    it '無効であること' do
+      post = build(:post, body: 'a' * 65536)
+      expect(post).to be_invalid
+      expect(post.errors[:body]).to include('は65535文字以内で入力してください')
+    end
+  end
+
+  context 'ジャンルの選択がない場合' do
+    it '無効であること' do
+      post = build(:post, genre: nil)
+      expect(post).to be_invalid
+      expect(post.errors[:genre]).to include('を入力してください')
+    end
+  end
+
+  context 'おすすめ度の選択がない場合' do
+    it '無効であること' do
+      post = build(:post, rating: nil)
+      expect(post).to be_invalid
+      expect(post.errors[:rating]).to include('を入力してください')
+    end
+  end
+
+  context '使った金額が登録できること' do
+    it '有効であること' do
+      post = build(:post)
+      post.amount = (0..6).to_a.sample
+      expect(post).to be_valid
+    end
+  end
+end

--- a/test/factories/posts.rb
+++ b/test/factories/posts.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :post do
+    sequence(:restaurant_name) { |n| "タイトル#{n}" }
+    sequence(:body) { |n| "本文#{n}" }
+    sequence(:address) { |n| "住所#{n}" }
+    genre { [0, 1, 2, 3, 4, 10, 11, 20, 21, 99].sample }
+    rating { [0, 1, 2, 3, 4].sample }
+    association :user
+  end
+end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/174
## やったこと
- Postのモデルスペック完了
- ratingがDB上ではnull:falseになっているのにモデルでpresence: trueになっていなかった箇所修正

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
![image](https://github.com/user-attachments/assets/4ca671f5-50f9-44b7-988b-3251da486a4f)


## その他