### PR TITLE
add: #175 Bookmarkモデルスペックの追加

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,5 @@
 class Bookmark < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  validates :user_id, uniqueness: { scope: :post_id }
 end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Bookmark, type: :model do
+  context '全てのフィールドが有効な場合' do
+    it '有効であること' do
+      bookmark = build(:bookmark)
+      expect(bookmark).to be_valid
+    end
+  end
+
+  context 'ユーザーと掲示板の組み合わせがユニークでない場合' do
+    it '無効であること' do
+      bookmark = create(:bookmark)
+      new_bookmark = build(:bookmark, user: bookmark.user, post: bookmark.post)
+      new_bookmark.valid?
+      expect(new_bookmark.errors[:user_id]).to include('はすでに存在します'), 'bookmarkとuserのユニークバリデーションが設定されていません'
+    end
+  end
+end

--- a/test/factories/bookmarks.rb
+++ b/test/factories/bookmarks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bookmark do
+    association :user
+    association :post
+  end
+end

--- a/test/factories/posts.rb
+++ b/test/factories/posts.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     sequence(:address) { |n| "住所#{n}" }
     genre { [0, 1, 2, 3, 4, 10, 11, 20, 21, 99].sample }
     rating { [0, 1, 2, 3, 4].sample }
+    latitude { 35.6895 }
+    longitude { 139.6917 }
     association :user
   end
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/175
## やったこと
- Bookmarkモデルのテスト実装
- spec/models/bookmark_spec.rbに`validates :user_id, uniqueness: { scope: :post_id }`を追加

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
![image](https://github.com/user-attachments/assets/e7c3f8cd-1a5d-4006-8836-bcfec13deb7a)


## その他