### PR TITLE
add: #180 ログイン後のプロフィールに関するテスト追加

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,4 +79,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include LoginMacros
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,6 +3,9 @@ Capybara.register_driver :remote_chrome do |app|
   options.add_argument('no-sandbox')
   options.add_argument('headless')
   options.add_argument('disable-gpu')
-  options.add_argument('window-size=1680,1050')
+  options.add_argument('window-size=1024,768')
+  options.add_argument('disable-dev-shm-usage') # /dev/shmの使用を無効にしてメモリを直接使用
+  options.add_argument('disable-software-rasterizer') # ソフトウェアラスタライザーを無効にする
+  options.add_argument('disable-extensions') # 拡張機能を無効にする
   Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV['SELENIUM_DRIVER_URL'], capabilities: options)
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -5,5 +5,6 @@ module LoginMacros
     fill_in 'メールアドレス', with: user.email
     fill_in 'パスワード', with: 'password'
     click_button 'ログイン'
+    visit current_path
   end
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,9 @@
+module LoginMacros
+  def login_as(user)
+    visit root_path
+    click_link 'ログインする'
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
+    click_button 'ログイン'
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 RSpec.describe 'Users', type: :system do
-  let(:user){ create(:user) }
+  let(:user) { create(:user) }
   describe 'ログイン前' do
     describe 'ユーザーの新規登録' do
       context 'フォームの入力値が正常' do
@@ -54,6 +54,36 @@ RSpec.describe 'Users', type: :system do
           expect(current_path).to eq login_path
         end
       end
+    end
+  end
+
+  describe 'ログイン後' do
+    before { login_as(user) }
+
+    describe 'ユーザー編集' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの編集が成功する' do
+          visit edit_mypage_profiles_path(user)
+          fill_in '名前', with: '太郎'
+          select '女性', from: 'user_gender'
+          select '20代', from: 'user_age'
+          click_button '登録'
+          expect(page).to have_content('ユーザー情報の更新に成功しました')
+          expect(current_path).to eq mypage_profiles_path
+        end
+      end
+
+      context  '名前が未入力' do
+        it 'ユーザーの編集が失敗する' do
+          visit edit_mypage_profiles_path(user)
+          fill_in '名前', with: ''
+          click_button '登録'
+          expect(page).to have_content 'ユーザー情報の更新に失敗しました'
+          expect(page).to have_content '名前を入力してください'
+          expect(current_path).to eq  mypage_profiles_path
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/181
## やったこと
- ログインモジュールの追加
  - Turbo関係で動きが不安定になるため再読み込みの設定
- ログイン後のプロフィールに関するテスト追加

## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 開発環境・GitHub Actionsともに問題なく動作

## その他