### PR TITLE
add: #183 UserSessionスペックの追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
 
+      - name: Archive Capybara screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: capybara-screenshots
+          path: tmp/capybara
+
   rubocop:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,7 +5,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_to root_path, success: 'ログインに成功しました'
+      redirect_to maps_path, success: 'ログインに成功しました'
     else
       flash.now[:alert] = 'ログインに失敗しました'
       render :new, status: :unprocessable_entity

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,11 @@ RSpec.configure do |config|
     end
   end
 
+  # スクショの削除
+  config.before(:all) do
+    FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true) unless ENV["CI"]
+  end
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'UserSessions', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'ログイン前' do
+    context 'フォームの入力値が正常' do
+      it 'ログイン処理が成功する' do
+        visit login_path
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード', with: 'password'
+        click_button 'ログイン'
+        expect(page).to have_content 'ログインに成功しました'
+        expect(current_path).to eq maps_path
+      end
+    end
+
+    context 'フォームが未入力' do
+      it 'ログイン処理が失敗する' do
+        visit login_path
+        fill_in 'メールアドレス', with: ''
+        fill_in 'パスワード', with: 'password'
+        click_button 'ログイン'
+        expect(page).to have_content 'ログインに失敗しました'
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する' do
+        login_as(user)
+        click_link 'ログアウト', match: :first
+        # ログアウトが成功したことを確認するテスト
+        page.accept_alert 'ログアウトしてもよろしいですか？'
+        expect(page).to have_content 'ログイン'
+        visit current_path
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/183
## やったこと
- UserSessionのRSpecの追加
-  ログイン前
  - フォームの入力値が正常 => ログイン処理が成功する
  - フォームの値が未入力 => ログイン失敗
- ログイン後
  - ログアウトボタンクリックする => ログアウトされる
## できなかったこと・やらなかったこと


## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 開発環境・GitHub Actionsにて動作確認済み

## その他