### PR TITLE
add: #188 ログイン前のPostスペック追加

### DIFF
--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+RSpec.describe 'Posts', type: :system do
+  let(:user){ create(:user) }
+  let(:post){ create(:post) }
+
+  describe 'ログイン前' do
+    describe 'ページ遷移確認' do
+      context '新規投稿ページにアクセス' do
+        it '新規登録ページへのアクセスが失敗する' do
+          visit new_post_path
+          expect(page).to have_content('ログインしてください')
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context '投稿編集ページにアクセス' do
+        it '投稿編集ページへのアクセスが失敗する' do
+          visit edit_post_path(post)
+          expect(page).to have_content('ログインしてください')
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context '投稿詳細ページにアクセス' do
+        it '投稿の詳細ページが表示される' do
+          visit post_path(post)
+          expect(page).to have_content post.restaurant_name
+          expect(current_path).to eq post_path(post)
+        end
+      end
+
+      context '投稿一覧(カード)にアクセス' do
+        it 'すべての投稿が表示される' do
+          post_list = create_list(:post, 3) #配列になっている
+          visit posts_path
+          expect(page).to have_content post_list[0].restaurant_name
+          expect(page).to have_content post_list[1].restaurant_name
+          expect(page).to have_content post_list[2].restaurant_name
+          expect(current_path).to eq posts_path
+        end
+      end
+
+      context '投稿一覧(マップ)にアクセス' do
+        xit 'すべての投稿が表示される' do
+
+        end
+      end
+    end
+  end
+end

--- a/test/factories/posts.rb
+++ b/test/factories/posts.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     sequence(:address) { |n| "住所#{n}" }
     genre { [0, 1, 2, 3, 4, 10, 11, 20, 21, 99].sample }
     rating { [0, 1, 2, 3, 4].sample }
-    latitude { 35.6895 }
-    longitude { 139.6917 }
+    latitude { 35.6803997 }
+    longitude { 139.7690174 }
     association :user
   end
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/188
## やったこと
- ログイン前のページ遷移に関するテストを追加
- テストのため、FactoryBotの緯度経度を変更

## できなかったこと・やらなかったこと
- 地図一覧系に関してはテスト書けず
- コードのリファクタリングと地図用のテストコードのissueを作成します

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 開発環境・GItHub Actionsで動作確認済み

## その他