### PR TITLE
add: #188 Postスペックの削除を追加

### DIFF
--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -47,4 +47,27 @@ RSpec.describe 'Posts', type: :system do
       end
     end
   end
+
+  describe 'ログイン後' do
+  before { login_as(user) }
+
+    describe '投稿編集' do
+      context '他ユーザーの投稿編集ページにアクセス' do
+        xit '編集ページへのアクセスが失敗する' do
+          # アクセス禁止に関わる処理を実装していないためスキップ
+        end
+      end
+    end
+
+    describe '投稿削除' do
+      it '投稿の削除が成功する' do
+        post = create(:post, user: user, restaurant_name: 'レストラン削除', body: 'さようなら')
+        visit post_path(post)
+        click_on '削除'
+        page.accept_alert '投稿を削除しますか？'
+        expect(page).to have_content('投稿を削除しました')
+        expect(current_path).to eq posts_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
## issue番号
close https://github.com/nakayama-bird/metime-meals/issues/189
## やったこと
- 投稿削除に関わるテストを追加

## できなかったこと・やらなかったこと
- 他ユーザーの編集画面のアクセスに関しては条件分岐の処理を書いていないため一旦保留

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）


## 動作確認
- 開発環境・GitHub Actionsで動作確認済み

## その他